### PR TITLE
Fix WPF ambiguities + Add MoodCatalog (eyes-only)

### DIFF
--- a/src/Virgil.App/GlobalUsings.WpfFix.cs
+++ b/src/Virgil.App/GlobalUsings.WpfFix.cs
@@ -1,0 +1,13 @@
+// Global aliases to ensure WPF types are selected over WinForms/Drawing
+#pragma warning disable 8019
+
+global using Application = System.Windows.Application;
+global using UserControl = System.Windows.Controls.UserControl;
+
+// Media shortcuts for ambiguous types
+global using Brush = System.Windows.Media.Brush;
+global using SolidColorBrush = System.Windows.Media.SolidColorBrush;
+global using Color = System.Windows.Media.Color;
+
+// Optional namespace alias used by some files
+global using Media = System.Windows.Media;

--- a/src/Virgil.Core/Services/MoodCatalog.cs
+++ b/src/Virgil.Core/Services/MoodCatalog.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Virgil.Core.Services
+{
+    public record MoodDescriptor(string EyesKey, string ColorHex);
+
+    /// <summary>
+    /// Default moods mapped to an eye-style key and a face color (eyes-only avatar).
+    /// Non-breaking: additive only.
+    /// </summary>
+    public static class MoodCatalog
+    {
+        public static readonly IReadOnlyDictionary<string, MoodDescriptor> Defaults =
+            new Dictionary<string, MoodDescriptor>
+            {
+                ["neutral"]   = new("neutral",  "#5A8F3F"),
+                ["happy"]     = new("smile",    "#5A8F3F"),
+                ["relaxed"]   = new("relaxed",  "#5A8F3F"),
+                ["sleepy"]    = new("sleepy",   "#5A8F3F"),
+                ["sad"]       = new("tear",     "#5A8F3F"),
+                ["thinking"]  = new("side",     "#5A8F3F"),
+                ["blink"]     = new("blink",    "#5A8F3F"),
+                ["surprised"] = new("round",    "#5A8F3F"),
+                ["inlove"]    = new("hearts",   "#FF66A6"),
+                ["cat"]       = new("cat",      "#FFFFFF"),
+                ["devil"]     = new("angry",    "#E53935"),
+                ["angry"]     = new("angry",    "#E53935"),
+                ["smirk"]     = new("smirk",    "#5A8F3F"),
+                ["wink"]      = new("wink",     "#5A8F3F"),
+                ["focus"]     = new("focus",    "#5A8F3F"),
+                ["confused"]  = new("confused", "#5A8F3F"),
+                ["sly"]       = new("sly",      "#5A8F3F"),
+                ["joy"]       = new("joy",      "#5A8F3F"),
+                ["neutral2"]  = new("neutral2", "#5A8F3F")
+            };
+    }
+}


### PR DESCRIPTION
This PR adds two small, non-breaking files to fix the build and prepare moods:

1) **src/Virgil.App/GlobalUsings.WpfFix.cs**
   - Global aliases to prefer WPF types and remove CS0104 ambiguities (`Application`, `UserControl`, `Brush`, `Color`, etc.).
2) **src/Virgil.Core/Services/MoodCatalog.cs**
   - A default set of moods (eyes-only) mapping names to eye-style keys and suggested face colors.

No existing files modified. After merge, CI should pass. If any file still needs WinForms types, use fully-qualified names (`System.Windows.Forms.*`).