### PR TITLE
Core: Phase 2 — real monitoring (CPU/RAM/Temp via WMI) + mood binding

### DIFF
--- a/src/Virgil.App/Services/IMonitoringService.cs
+++ b/src/Virgil.App/Services/IMonitoringService.cs
@@ -1,0 +1,8 @@
+namespace Virgil.App.Services;
+
+public record Metrics(double Cpu, double Ram, double CpuTemp);
+
+public interface IMonitoringService
+{
+    Metrics Read();
+}

--- a/src/Virgil.App/Services/MonitoringService.cs
+++ b/src/Virgil.App/Services/MonitoringService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Management;
+
+namespace Virgil.App.Services;
+
+public class MonitoringService : IMonitoringService
+{
+    public Metrics Read()
+    {
+        var cpu = ReadCpu();
+        var ram = ReadRam();
+        var temp = ReadCpuTemp();
+        return new Metrics(cpu, ram, temp);
+    }
+
+    private static double ReadCpu()
+    {
+        using var searcher = new ManagementObjectSearcher("root/cimv2", "SELECT PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name='_Total'");
+        foreach (ManagementObject obj in searcher.Get())
+        {
+            if (obj["PercentProcessorTime"] is uint v) return Math.Clamp(v, 0, 100);
+        }
+        return 0;
+    }
+
+    private static double ReadRam()
+    {
+        using var searcher = new ManagementObjectSearcher("root/cimv2", "SELECT FreePhysicalMemory, TotalVisibleMemorySize FROM Win32_OperatingSystem");
+        foreach (ManagementObject obj in searcher.Get())
+        {
+            double freeKb = Convert.ToDouble(obj["FreePhysicalMemory"]);
+            double totalKb = Convert.ToDouble(obj["TotalVisibleMemorySize"]);
+            if (totalKb > 0)
+            {
+                double used = 100.0 - (freeKb / totalKb * 100.0);
+                return Math.Clamp(used, 0, 100);
+            }
+        }
+        return 0;
+    }
+
+    private static double ReadCpuTemp()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher("root/wmi", "SELECT CurrentTemperature FROM MSAcpi_ThermalZoneTemperature");
+            foreach (ManagementObject obj in searcher.Get())
+            {
+                if (obj["CurrentTemperature"] is uint t)
+                {
+                    // Kelvin * 10 to Celsius
+                    return Math.Round((t / 10.0 - 273.15), 1);
+                }
+            }
+        }
+        catch { }
+        return 0; // fallback if not available
+    }
+}

--- a/src/Virgil.App/ViewModels/MainViewModel.cs
+++ b/src/Virgil.App/ViewModels/MainViewModel.cs
@@ -5,12 +5,15 @@ using System.Runtime.CompilerServices;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using Virgil.App.Services;
 
 namespace Virgil.App.ViewModels;
 
 public class MainViewModel : INotifyPropertyChanged
 {
     private readonly DispatcherTimer _timer = new() { Interval = TimeSpan.FromSeconds(1) };
+    private readonly IMonitoringService _mon = new MonitoringService();
+
     private string _headerStatus = "Prêt";
     private string _footerStatus = string.Empty;
     private double _cpu = 0, _ram = 0, _gpu = 0;
@@ -53,10 +56,18 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        Messages.Add("Virgil prêt. Avatar dynamique activé.");
+        Messages.Add("Virgil prêt. Monitoring activé.");
         FooterStatus = "UI redesign";
-        _timer.Tick += (_, _) => OnPropertyChanged(nameof(Now));
+        _timer.Tick += (_, _) => { OnTick(); OnPropertyChanged(nameof(Now)); };
         _timer.Start();
+    }
+
+    private void OnTick()
+    {
+        var m = _mon.Read();
+        CpuUsage = m.Cpu;
+        RamUsage = m.Ram;
+        CpuTemp = m.CpuTemp;
     }
 
     private void UpdateMood()

--- a/src/Virgil.App/Virgil.App.csproj
+++ b/src/Virgil.App/Virgil.App.csproj
@@ -12,4 +12,7 @@
   <ItemGroup>
     <Resource Include="assets\avatar\*.png" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="8.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Phase 2 (première passe) :

- Nouveau service `Services/MonitoringService` (WMI)
  - CPU: `Win32_PerfFormattedData_PerfOS_Processor` (`_Total`)
  - RAM: `Win32_OperatingSystem` (calcul % utilisé)
  - Temp CPU (best effort): `MSAcpi_ThermalZoneTemperature` (fallback 0)
- Interface `IMonitoringService` + record `Metrics`
- `MainViewModel` connecté au service, tick 1s, mise à jour humeurs.
- `Virgil.App.csproj`: ajout du package `System.Management` pour WMI.

Prochaines étapes: GPU usage, disk I/O, réseau, et règles d’humeur affinées + scheduler auto-maintenance.
