### PR TITLE
Core: extend monitoring (Disk/Net) + stub maintenance scheduler

### DIFF
--- a/src/Virgil.App/MainWindow.xaml
+++ b/src/Virgil.App/MainWindow.xaml
@@ -30,8 +30,12 @@
                     <Separator/>
                     <TextBlock Text="{Binding CpuUsage,StringFormat=Cpu {0:F0}%}" Foreground="#E6E6E6"/>
                     <TextBlock Text="{Binding RamUsage,StringFormat=Ram {0:F0}%}" Foreground="#E6E6E6"/>
-                    <TextBlock Text="{Binding GpuUsage,StringFormat=Gpu {0:F0}%}" Foreground="#E6E6E6"/>
                     <TextBlock Text="{Binding CpuTemp,StringFormat=Temp {0:F0}°C}" Foreground="#E6E6E6"/>
+                    <Separator/>
+                    <TextBlock Text="{Binding DiskReadMBs,StringFormat=Disk R {0:F2} MB/s}" Foreground="#E6E6E6"/>
+                    <TextBlock Text="{Binding DiskWriteMBs,StringFormat=Disk W {0:F2} MB/s}" Foreground="#E6E6E6"/>
+                    <TextBlock Text="{Binding NetDownMbps,StringFormat=Net ↓ {0:F2} Mb/s}" Foreground="#E6E6E6"/>
+                    <TextBlock Text="{Binding NetUpMbps,StringFormat=Net ↑ {0:F2} Mb/s}" Foreground="#E6E6E6"/>
                 </StackPanel>
             </Border>
 

--- a/src/Virgil.App/Services/IMaintenanceScheduler.cs
+++ b/src/Virgil.App/Services/IMaintenanceScheduler.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Virgil.App.Services;
+
+public interface IMaintenanceScheduler
+{
+    DateTime? NextPlannedRun { get; }
+    void PlanDaily(TimeSpan atTimeLocal);
+    void Cancel();
+}

--- a/src/Virgil.App/Services/IMonitoringService.cs
+++ b/src/Virgil.App/Services/IMonitoringService.cs
@@ -1,6 +1,6 @@
 namespace Virgil.App.Services;
 
-public record Metrics(double Cpu, double Ram, double CpuTemp);
+public record Metrics(double Cpu, double Ram, double CpuTemp, double DiskReadMBs, double DiskWriteMBs, double NetUpMbps, double NetDownMbps);
 
 public interface IMonitoringService
 {

--- a/src/Virgil.App/Services/LocalMaintenanceScheduler.cs
+++ b/src/Virgil.App/Services/LocalMaintenanceScheduler.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Virgil.App.Services;
+
+// Stub: planificateur local (mémoire) – branchement futur sur schtasks.exe / Task Scheduler API
+public class LocalMaintenanceScheduler : IMaintenanceScheduler
+{
+    public DateTime? NextPlannedRun { get; private set; }
+
+    public void PlanDaily(TimeSpan atTimeLocal)
+    {
+        var now = DateTime.Now;
+        var next = new DateTime(now.Year, now.Month, now.Day, atTimeLocal.Hours, atTimeLocal.Minutes, 0);
+        if (next <= now) next = next.AddDays(1);
+        NextPlannedRun = next;
+    }
+
+    public void Cancel() => NextPlannedRun = null;
+}

--- a/src/Virgil.App/Services/MonitoringService.cs
+++ b/src/Virgil.App/Services/MonitoringService.cs
@@ -11,31 +11,26 @@ public class MonitoringService : IMonitoringService
         var cpu = ReadCpu();
         var ram = ReadRam();
         var temp = ReadCpuTemp();
-        return new Metrics(cpu, ram, temp);
+        var (r,w) = ReadDisk();
+        var (up,down) = ReadNet();
+        return new Metrics(cpu, ram, temp, r, w, up, down);
     }
 
     private static double ReadCpu()
     {
-        using var searcher = new ManagementObjectSearcher("root/cimv2", "SELECT PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name='_Total'");
-        foreach (ManagementObject obj in searcher.Get())
-        {
-            if (obj["PercentProcessorTime"] is uint v) return Math.Clamp(v, 0, 100);
-        }
+        using var s = new ManagementObjectSearcher("root/cimv2", "SELECT PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name='_Total'");
+        foreach (ManagementObject o in s.Get()) if (o["PercentProcessorTime"] is uint v) return Math.Clamp(v, 0, 100);
         return 0;
     }
 
     private static double ReadRam()
     {
-        using var searcher = new ManagementObjectSearcher("root/cimv2", "SELECT FreePhysicalMemory, TotalVisibleMemorySize FROM Win32_OperatingSystem");
-        foreach (ManagementObject obj in searcher.Get())
+        using var s = new ManagementObjectSearcher("root/cimv2", "SELECT FreePhysicalMemory, TotalVisibleMemorySize FROM Win32_OperatingSystem");
+        foreach (ManagementObject o in s.Get())
         {
-            double freeKb = Convert.ToDouble(obj["FreePhysicalMemory"]);
-            double totalKb = Convert.ToDouble(obj["TotalVisibleMemorySize"]);
-            if (totalKb > 0)
-            {
-                double used = 100.0 - (freeKb / totalKb * 100.0);
-                return Math.Clamp(used, 0, 100);
-            }
+            double freeKb = Convert.ToDouble(o["FreePhysicalMemory"]);
+            double totalKb = Convert.ToDouble(o["TotalVisibleMemorySize"]);
+            if (totalKb > 0) return Math.Clamp(100.0 - (freeKb/totalKb*100.0), 0, 100);
         }
         return 0;
     }
@@ -44,17 +39,40 @@ public class MonitoringService : IMonitoringService
     {
         try
         {
-            using var searcher = new ManagementObjectSearcher("root/wmi", "SELECT CurrentTemperature FROM MSAcpi_ThermalZoneTemperature");
-            foreach (ManagementObject obj in searcher.Get())
+            using var s = new ManagementObjectSearcher("root/wmi", "SELECT CurrentTemperature FROM MSAcpi_ThermalZoneTemperature");
+            foreach (ManagementObject o in s.Get()) if (o["CurrentTemperature"] is uint t) return Math.Round((t/10.0 - 273.15), 1);
+        } catch { }
+        return 0;
+    }
+
+    private static (double readMBs, double writeMBs) ReadDisk()
+    {
+        try
+        {
+            using var s = new ManagementObjectSearcher("root/cimv2", "SELECT DiskReadBytesPersec, DiskWriteBytesPersec FROM Win32_PerfFormattedData_PerfDisk_LogicalDisk WHERE Name='_Total'");
+            foreach (ManagementObject o in s.Get())
             {
-                if (obj["CurrentTemperature"] is uint t)
-                {
-                    // Kelvin * 10 to Celsius
-                    return Math.Round((t / 10.0 - 273.15), 1);
-                }
+                double r = Convert.ToDouble(o["DiskReadBytesPersec"]) / (1024*1024.0);
+                double w = Convert.ToDouble(o["DiskWriteBytesPersec"]) / (1024*1024.0);
+                return (Math.Round(r,2), Math.Round(w,2));
             }
-        }
-        catch { }
-        return 0; // fallback if not available
+        } catch { }
+        return (0,0);
+    }
+
+    private static (double upMbps, double downMbps) ReadNet()
+    {
+        try
+        {
+            using var s = new ManagementObjectSearcher("root/cimv2", "SELECT BytesReceivedPersec, BytesSentPersec FROM Win32_PerfFormattedData_Tcpip_NetworkInterface");
+            double up=0, down=0;
+            foreach (ManagementObject o in s.Get())
+            {
+                down += Convert.ToDouble(o["BytesReceivedPersec"]);
+                up   += Convert.ToDouble(o["BytesSentPersec"]);
+            }
+            return (Math.Round(up*8/(1024*1024.0),2), Math.Round(down*8/(1024*1024.0),2));
+        } catch { }
+        return (0,0);
     }
 }

--- a/src/Virgil.App/ViewModels/MainViewModel.cs
+++ b/src/Virgil.App/ViewModels/MainViewModel.cs
@@ -13,11 +13,13 @@ public class MainViewModel : INotifyPropertyChanged
 {
     private readonly DispatcherTimer _timer = new() { Interval = TimeSpan.FromSeconds(1) };
     private readonly IMonitoringService _mon = new MonitoringService();
+    private readonly IMaintenanceScheduler _sched = new LocalMaintenanceScheduler();
 
     private string _headerStatus = "Prêt";
     private string _footerStatus = string.Empty;
     private double _cpu = 0, _ram = 0, _gpu = 0;
     private double _cpuTemp = 0;
+    private double _diskR = 0, _diskW = 0, _netUp = 0, _netDown = 0;
     private Mood _mood = Mood.Sleepy;
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -32,11 +34,14 @@ public class MainViewModel : INotifyPropertyChanged
     public double RamUsage { get => _ram; set { _ram = value; OnPropertyChanged(); UpdateMood(); } }
     public double GpuUsage { get => _gpu; set { _gpu = value; OnPropertyChanged(); UpdateMood(); } }
     public double CpuTemp { get => _cpuTemp; set { _cpuTemp = value; OnPropertyChanged(); UpdateMood(); } }
+    public double DiskReadMBs { get => _diskR; set { _diskR = value; OnPropertyChanged(); } }
+    public double DiskWriteMBs { get => _diskW; set { _diskW = value; OnPropertyChanged(); } }
+    public double NetUpMbps { get => _netUp; set { _netUp = value; OnPropertyChanged(); } }
+    public double NetDownMbps { get => _netDown; set { _netDown = value; OnPropertyChanged(); } }
 
     public Mood Mood { get => _mood; set { _mood = value; OnPropertyChanged(); OnPropertyChanged(nameof(MoodColor)); OnPropertyChanged(nameof(AvatarSource)); } }
 
     public SolidColorBrush MoodColor => MoodPalette.For(Mood);
-
     public ImageSource AvatarSource => new BitmapImage(new Uri($"pack://application:,,,/assets/avatar/{MoodToFile(Mood)}"));
 
     private static string MoodToFile(Mood m) => m switch
@@ -56,8 +61,9 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        Messages.Add("Virgil prêt. Monitoring activé.");
-        FooterStatus = "UI redesign";
+        Messages.Add("Virgil prêt. Monitoring ++ et planif.");
+        _sched.PlanDaily(new TimeSpan(3, 0, 0)); // 03:00 local, stub
+        FooterStatus = _sched.NextPlannedRun.HasValue ? $"Maintenance planifiée: {_sched.NextPlannedRun}" : "Maintenance non planifiée";
         _timer.Tick += (_, _) => { OnTick(); OnPropertyChanged(nameof(Now)); };
         _timer.Start();
     }
@@ -68,6 +74,10 @@ public class MainViewModel : INotifyPropertyChanged
         CpuUsage = m.Cpu;
         RamUsage = m.Ram;
         CpuTemp = m.CpuTemp;
+        DiskReadMBs = m.DiskReadMBs;
+        DiskWriteMBs = m.DiskWriteMBs;
+        NetUpMbps = m.NetUpMbps;
+        NetDownMbps = m.NetDownMbps;
     }
 
     private void UpdateMood()


### PR DESCRIPTION
- **Monitoring étendu** via WMI:
  - Disque: `Win32_PerfFormattedData_PerfDisk_LogicalDisk` (Read/Write MB/s)
  - Réseau: `Win32_PerfFormattedData_Tcpip_NetworkInterface` (Up/Down Mbps, somme des interfaces)
- **Scheduler local (stub)**: planification quotidienne en mémoire (03:00) avec `LocalMaintenanceScheduler`
- **UI/ViewModel**: nouveaux bindings pour Disk R/W et Net Up/Down, statut de planification en barre d’état

Prochaines étapes: GPU, I/O disque par process, détection d’activité (jeu/web/idle), bascule d’humeur contextuelle + tâches planifiées réelles (schtasks/Task Scheduler).