### PR TITLE
Fix(restore): resolve NU1605 by bumping System.Management to 9.0.0

### DIFF
--- a/src/Virgil.App/Virgil.App.csproj
+++ b/src/Virgil.App/Virgil.App.csproj
@@ -13,6 +13,6 @@
     <Resource Include="assets\avatar\*.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="System.Management" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Restore échoue avec NU1605 (downgrade):
- Virgil.Core -> LibreHardwareMonitorLib (>= System.Management 9.0.0)
- Virgil.App référençait System.Management 8.0.0

Correction: alignement de `Virgil.App` sur **System.Management 9.0.0** pour éviter le downgrade et stabiliser le `dotnet restore`.
