### PR TITLE
Phase 5: GPU monitoring + ActivityDetector + Cleaning dry-run + UI hooks

### DIFF
--- a/src/Virgil.App/MainWindow.xaml
+++ b/src/Virgil.App/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Virgil.App.Controls"
-        Title="Virgil" Height="680" Width="1080" MinHeight="560" MinWidth="900" Background="#0E0E10">
+        Title="Virgil" Height="720" Width="1120" MinHeight="560" MinWidth="900" Background="#0E0E10">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="48"/>
@@ -21,7 +21,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="300"/>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="320"/>
+                <ColumnDefinition Width="360"/>
             </Grid.ColumnDefinitions>
 
             <Border Background="#141418" CornerRadius="8" Padding="14" Margin="0,0,10,0">
@@ -30,7 +30,12 @@
                     <Separator/>
                     <TextBlock Text="{Binding CpuUsage,StringFormat=Cpu {0:F0}%}" Foreground="#E6E6E6"/>
                     <TextBlock Text="{Binding RamUsage,StringFormat=Ram {0:F0}%}" Foreground="#E6E6E6"/>
-                    <TextBlock Text="{Binding CpuTemp,StringFormat=Temp {0:F0}°C}" Foreground="#E6E6E6"/>
+                    <TextBlock Text="{Binding CpuTemp,StringFormat=Temp CPU {0:F0}°C}" Foreground="#E6E6E6"/>
+                    <Separator/>
+                    <TextBlock Text="{Binding GpuUsage,StringFormat=GPU {0:F0}%}" Foreground="#E6E6E6"/>
+                    <TextBlock Text="{Binding GpuTemp,StringFormat=Temp GPU {0:F0}°C}" Foreground="#E6E6E6"/>
+                    <Separator/>
+                    <TextBlock Text="{Binding Activity}" Foreground="#CFCFCF"/>
                 </StackPanel>
             </Border>
 
@@ -54,6 +59,7 @@
                     <Separator/>
                     <Button Content="Maintenance complète" Margin="0,6" Command="{Binding CmdMaintenanceAll}"/>
                     <Button Content="Nettoyage intelligent" Margin="0,6" Command="{Binding CmdCleanSmart}"/>
+                    <Button Content="Dry-run nettoyage" Margin="0,6" Command="{Binding CmdCleanDryRun}"/>
                     <Button Content="Tout mettre à jour (winget)" Margin="0,6" Command="{Binding CmdWingetUpgrade}"/>
                     <Button Content="Apps Microsoft Store" Margin="0,6" Command="{Binding CmdStoreUpdate}"/>
                     <Button Content="Windows Update" Margin="0,6" Command="{Binding CmdWindowsUpdate}"/>

--- a/src/Virgil.App/Services/ActivityDetector.cs
+++ b/src/Virgil.App/Services/ActivityDetector.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Virgil.App.Services;
+
+public class ActivityDetector : IActivityDetector
+{
+    [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll", SetLastError=true)] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    private static readonly string[] Browsers = new[]{ "chrome", "msedge", "firefox", "opera", "brave" };
+    private static readonly string[] GamesHints = new[]{ "steam", "epicgameslauncher", "battle.net", "riotclient", "ubisoftconnect" };
+
+    public ActivityKind Detect()
+    {
+        try
+        {
+            var hwnd = GetForegroundWindow();
+            if (hwnd == IntPtr.Zero) return ActivityKind.Idle;
+            GetWindowThreadProcessId(hwnd, out var pid);
+            var p = Process.GetProcessById((int)pid);
+            var name = (p.ProcessName ?? string.Empty).ToLowerInvariant();
+            if (Browsers.Any(b => name.Contains(b))) return ActivityKind.Web;
+            if (GamesHints.Any(g => name.Contains(g))) return ActivityKind.Game;
+            return ActivityKind.Work;
+        }
+        catch { return ActivityKind.Idle; }
+    }
+}

--- a/src/Virgil.App/Services/CleaningService.cs
+++ b/src/Virgil.App/Services/CleaningService.cs
@@ -10,21 +10,16 @@ public class CleaningService : ICleaningService
     public async Task<int> CleanIntelligentAsync(bool dryRun = false)
     {
         int deleted = 0;
-
-        // System/temp locations
         deleted += await PurgeDir(Path.GetTempPath(), dryRun);
         var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
         deleted += await PurgeDir(Path.Combine(winDir, "Temp"), dryRun);
         deleted += await PurgeDir(Path.Combine(winDir, "Prefetch"), dryRun, pattern: "*.pf");
         deleted += await PurgeDir(Path.Combine(winDir, "SoftwareDistribution", "Download"), dryRun);
-
-        // Browsers caches (best effort)
         var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         deleted += await PurgeDir(Path.Combine(local, "Google", "Chrome", "User Data", "Default", "Cache"), dryRun);
         deleted += await PurgeDir(Path.Combine(local, "Microsoft", "Edge", "User Data", "Default", "Cache"), dryRun);
         var ffProfiles = Path.Combine(local, "Mozilla", "Firefox", "Profiles");
         deleted += await PurgeDir(ffProfiles, dryRun, pattern: "*cache*");
-
         return deleted;
     }
 
@@ -40,7 +35,6 @@ public class CleaningService : ICleaningService
                 {
                     try { if (!dryRun) File.Delete(file); count++; } catch { }
                 }
-                // Try remove empty subdirs (depth-first)
                 foreach (var dir in Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories).OrderByDescending(d => d.Length))
                 {
                     try { if (!dryRun) Directory.Delete(dir, false); } catch { }

--- a/src/Virgil.App/Services/GpuService.cs
+++ b/src/Virgil.App/Services/GpuService.cs
@@ -1,0 +1,30 @@
+using LibreHardwareMonitor.Hardware;
+
+namespace Virgil.App.Services;
+
+public class GpuService : IGpuService
+{
+    private readonly Computer _comp;
+
+    public GpuService()
+    {
+        _comp = new Computer { IsGpuEnabled = true };
+        _comp.Open();
+    }
+
+    public (double usage, double temp) Read()
+    {
+        double u = 0, t = 0;
+        foreach (var hw in _comp.Hardware)
+        {
+            if (hw.HardwareType != HardwareType.GpuNvidia && hw.HardwareType != HardwareType.GpuAmd && hw.HardwareType != HardwareType.GpuIntel) continue;
+            hw.Update();
+            foreach (var s in hw.Sensors)
+            {
+                if (s.SensorType == SensorType.Temperature && s.Name.Contains("Core")) t = s.Value ?? t;
+                if (s.SensorType == SensorType.Load && s.Name.Contains("Core")) u = s.Value ?? u;
+            }
+        }
+        return (u, t);
+    }
+}

--- a/src/Virgil.App/Services/IActivityDetector.cs
+++ b/src/Virgil.App/Services/IActivityDetector.cs
@@ -1,0 +1,8 @@
+namespace Virgil.App.Services;
+
+public enum ActivityKind { Idle, Web, Game, Work }
+
+public interface IActivityDetector
+{
+    ActivityKind Detect();
+}

--- a/src/Virgil.App/Services/IGpuService.cs
+++ b/src/Virgil.App/Services/IGpuService.cs
@@ -1,0 +1,6 @@
+namespace Virgil.App.Services;
+
+public interface IGpuService
+{
+    (double usage, double temp) Read();
+}

--- a/src/Virgil.App/ViewModels/MainViewModel.cs
+++ b/src/Virgil.App/ViewModels/MainViewModel.cs
@@ -16,6 +16,8 @@ public class MainViewModel : INotifyPropertyChanged
 {
     private readonly DispatcherTimer _timer = new() { Interval = TimeSpan.FromSeconds(1) };
     private readonly IMonitoringService _mon = new MonitoringService();
+    private readonly IGpuService _gpuSvc = new GpuService();
+    private readonly IActivityDetector _act = new ActivityDetector();
     private readonly IMaintenanceService _ops = new MaintenanceService(new ProcessRunner());
     private readonly ICleaningService _clean = new CleaningService();
     private readonly IStoreService _store = new StoreService(new ProcessRunner());
@@ -24,9 +26,11 @@ public class MainViewModel : INotifyPropertyChanged
 
     private string _headerStatus = "Prêt";
     private string _footerStatus = string.Empty;
-    private double _cpu = 0, _ram = 0, _gpu = 0;
+    private double _cpu = 0, _ram = 0;
+    private double _gpu = 0, _gpuTemp = 0;
     private double _cpuTemp = 0;
     private Mood _mood = Mood.Sleepy;
+    private ActivityKind _activity = ActivityKind.Idle;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -39,7 +43,9 @@ public class MainViewModel : INotifyPropertyChanged
     public double CpuUsage { get => _cpu; set { _cpu = value; OnPropertyChanged(); UpdateMood(); } }
     public double RamUsage { get => _ram; set { _ram = value; OnPropertyChanged(); UpdateMood(); } }
     public double GpuUsage { get => _gpu; set { _gpu = value; OnPropertyChanged(); UpdateMood(); } }
-    public double CpuTemp { get => _cpuTemp; set { _cpuTemp = value; OnPropertyChanged(); UpdateMood(); } }
+    public double GpuTemp  { get => _gpuTemp; set { _gpuTemp = value; OnPropertyChanged(); UpdateMood(); } }
+    public double CpuTemp  { get => _cpuTemp; set { _cpuTemp = value; OnPropertyChanged(); UpdateMood(); } }
+    public ActivityKind Activity { get => _activity; set { _activity = value; OnPropertyChanged(); UpdateMood(); } }
 
     public Mood Mood { get => _mood; set { _mood = value; OnPropertyChanged(); OnPropertyChanged(nameof(MoodColor)); OnPropertyChanged(nameof(AvatarSource)); } }
 
@@ -47,11 +53,12 @@ public class MainViewModel : INotifyPropertyChanged
     public System.Windows.Media.ImageSource AvatarSource => new BitmapImage(new Uri($"pack://application:,,,/assets/avatar/{MoodToFile(Mood)}"));
 
     public ICommand CmdMaintenanceAll   => new SimpleCommand(async () => await DoMaintenanceAll());
+    public ICommand CmdCleanSmart       => new SimpleCommand(async () => await DoCleanSmart(dryRun:false));
+    public ICommand CmdCleanDryRun      => new SimpleCommand(async () => await DoCleanSmart(dryRun:true));
     public ICommand CmdWingetUpgrade    => new SimpleCommand(async () => await DoWinget());
+    public ICommand CmdStoreUpdate      => new SimpleCommand(async () => await DoStore());
     public ICommand CmdWindowsUpdate    => new SimpleCommand(async () => await DoWU());
     public ICommand CmdDefenderUpdate   => new SimpleCommand(async () => await DoDef());
-    public ICommand CmdCleanSmart       => new SimpleCommand(async () => await DoCleanSmart());
-    public ICommand CmdStoreUpdate      => new SimpleCommand(async () => await DoStore());
     public ICommand CmdDriversUpdate    => new SimpleCommand(async () => await DoDrivers());
 
     private static string MoodToFile(Mood m) => m switch
@@ -71,7 +78,7 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        Messages.Add("Virgil prêt. Maintenance ++.");
+        Messages.Add("Virgil prêt. GPU + activité + dry-run.");
         _timer.Tick += (_, _) => { OnTick(); OnPropertyChanged(nameof(Now)); };
         _timer.Start();
     }
@@ -82,71 +89,36 @@ public class MainViewModel : INotifyPropertyChanged
         CpuUsage = m.Cpu;
         RamUsage = m.Ram;
         CpuTemp = m.CpuTemp;
+
+        var g = _gpuSvc.Read();
+        GpuUsage = g.usage;
+        GpuTemp = g.temp;
+
+        Activity = _act.Detect();
     }
 
     private void UpdateMood()
     {
-        if (CpuTemp > 80 || CpuUsage > 90 || RamUsage > 90) Mood = Mood.Alert;
-        else if (CpuUsage > 70 || RamUsage > 80) Mood = Mood.Warn;
-        else if (CpuUsage > 35) Mood = Mood.Focused;
+        if (CpuTemp > 80 || GpuTemp > 85 || CpuUsage > 90 || RamUsage > 90 || GpuUsage > 95) Mood = Mood.Alert;
+        else if (CpuUsage > 70 || RamUsage > 80 || GpuUsage > 80) Mood = Mood.Warn;
+        else if (Activity == ActivityKind.Game || Activity == ActivityKind.Work) Mood = Mood.Focused;
         else Mood = Mood.Happy;
     }
 
-    private async Task DoMaintenanceAll()
+    private async Task DoMaintenanceAll(){ await DoCleanSmart(); await DoWinget(); await DoStore(); await DoWU(); await DoDef(); await DoDrivers(); }
+
+    private async Task DoCleanSmart(bool dryRun=false)
     {
-        Messages.Add("Mode maintenance activé."); _log.Info("Maintenance all");
-        await DoCleanSmart();
-        await DoWinget();
-        await DoStore();
-        await DoWU();
-        await DoDef();
-        await DoDrivers();
-        Messages.Add("Maintenance terminée."); _log.Info("Maintenance done");
+        Messages.Add(dryRun ? "Dry-run du nettoyage…" : "Nettoyage intelligent en cours...");
+        var n = await _clean.CleanIntelligentAsync(dryRun);
+        Messages.Add(dryRun ? ($"Dry-run: fichiers ciblés ~{n}.") : ($"Fichiers supprimés: {n}."));
     }
 
-    private async Task DoCleanSmart()
-    {
-        Messages.Add("Nettoyage intelligent en cours..."); _log.Info("Clean smart");
-        var n = await _clean.CleanIntelligentAsync();
-        Messages.Add($"Fichiers supprimés: {n}."); _log.Info($"Cleaned files: {n}");
-    }
-
-    private async Task DoStore()
-    {
-        Messages.Add("Store: mise à jour des apps UWP."); _log.Info("Store update");
-        var code = await _store.UpdateStoreAppsAsync();
-        Messages.Add(code==0 ? "Store OK." : $"Store code {code}.");
-    }
-
-    private async Task DoDrivers()
-    {
-        Messages.Add("Pilotes: sauvegarde + scan mise à jour."); _log.Info("Drivers backup+scan");
-        var backupDir = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Virgil", "drivers-backup");
-        await _drivers.BackupDriversAsync(backupDir);
-        var code = await _drivers.ScanAndUpdateDriversAsync();
-        Messages.Add(code==0 ? "Pilotes: OK." : $"Pilotes code {code}.");
-    }
-
-    private async Task DoWinget()
-    {
-        Messages.Add("Applications et jeux: mise à jour."); _log.Info("Winget upgrade");
-        var code = await _ops.RunWingetUpgradeAsync();
-        Messages.Add(code==0 ? "Mises à jour apps/jeux OK." : $"Winget code {code}.");
-    }
-
-    private async Task DoWU()
-    {
-        Messages.Add("Windows Update: scan, download, install."); _log.Info("WU");
-        var code = await _ops.RunWindowsUpdateAsync();
-        Messages.Add(code==0 ? "Windows Update OK." : $"Windows Update code {code}.");
-    }
-
-    private async Task DoDef()
-    {
-        Messages.Add("Defender: signatures + scan rapide."); _log.Info("Defender");
-        var code = await _ops.RunDefenderUpdateAndQuickScanAsync();
-        Messages.Add(code==0 ? "Defender OK." : $"Defender code {code}.");
-    }
+    private async Task DoStore(){ var code = await _store.UpdateStoreAppsAsync(); Messages.Add(code==0?"Store OK.":$"Store code {code}."); }
+    private async Task DoDrivers(){ var b=System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),"Virgil","drivers-backup"); await _drivers.BackupDriversAsync(b); var code=await _drivers.ScanAndUpdateDriversAsync(); Messages.Add(code==0?"Pilotes: OK.":$"Pilotes code {code}."); }
+    private async Task DoWinget(){ var code = await _ops.RunWingetUpgradeAsync(); Messages.Add(code==0?"Mises à jour apps/jeux OK.":$"Winget code {code}."); }
+    private async Task DoWU(){ var code = await _ops.RunWindowsUpdateAsync(); Messages.Add(code==0?"Windows Update OK.":$"Windows Update code {code}."); }
+    private async Task DoDef(){ var code = await _ops.RunDefenderUpdateAndQuickScanAsync(); Messages.Add(code==0?"Defender OK.":$"Defender code {code}."); }
 
     private void OnPropertyChanged([CallerMemberName] string? name = null)
         => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));


### PR DESCRIPTION
Ajouts majeurs :

- **GPU monitoring** via LibreHardwareMonitor (usage + température) exposé par `IGpuService`/`GpuService`.
- **ActivityDetector** (détection simple de l’activité en cours : Idle/Web/Game/Work) basé sur la fenêtre au premier plan.
- **Cleaning dry-run** : `CleanIntelligentAsync(bool dryRun)` pour compter sans supprimer, avec bouton **Dry-run** dans l’UI.
- **ViewModel/UI** : nouvelles propriétés (GPU usage/temp, activité), commandes et boutons reliés.

Bénéfices : humeur plus crédible (prise en compte GPU + activité), possibilité de simuler le nettoyage avant purge réelle.

Étapes suivantes proposées : enrichir l’activité (profilage process réseau bavards), WinSxS/DSIM en option, drivers OEM (Intel/AMD/NVIDIA), rapport final HTML/Markdown.
