### PR TITLE
Phase 7: Nettoyage avancé (MRU/miniatures/cache Explorer) + comptage octets + bouton UI

### DIFF
--- a/src/Virgil.App/MainWindow.xaml
+++ b/src/Virgil.App/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Virgil.App.Controls"
-        Title="Virgil" Height="740" Width="1120" MinHeight="560" MinWidth="900" Background="#0E0E10">
+        Title="Virgil" Height="750" Width="1120" MinHeight="560" MinWidth="900" Background="#0E0E10">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="48"/>
@@ -50,15 +50,11 @@
 
             <Border Grid.Column="2" Background="#141418" CornerRadius="8" Padding="14" Margin="10,0,0,0">
                 <StackPanel>
-                    <TextBlock Text="Actions avancées" FontWeight="SemiBold" Foreground="#E6E6E6"/>
+                    <TextBlock Text="Actions" FontWeight="SemiBold" Foreground="#E6E6E6"/>
                     <Separator/>
-                    <Button Content="DISM: StartComponentCleanup" Margin="0,6" Command="{Binding CmdDismCleanup}"/>
-                    <Button Content="Top talkers réseau" Margin="0,6" Command="{Binding CmdTopTalkers}"/>
-                    <Button Content="Exporter rapport HTML (jour)" Margin="0,6" Command="{Binding CmdExportReport}"/>
-                    <Separator/>
-                    <TextBlock Text="Maintenance" FontWeight="SemiBold" Foreground="#E6E6E6"/>
                     <Button Content="Maintenance complète" Margin="0,6" Command="{Binding CmdMaintenanceAll}"/>
                     <Button Content="Nettoyage intelligent" Margin="0,6" Command="{Binding CmdCleanSmart}"/>
+                    <Button Content="Nettoyage avancé" Margin="0,6" Command="{Binding CmdCleanAdvanced}"/>
                     <Button Content="Tout mettre à jour (winget)" Margin="0,6" Command="{Binding CmdWingetUpgrade}"/>
                     <Button Content="Apps Microsoft Store" Margin="0,6" Command="{Binding CmdStoreUpdate}"/>
                     <Button Content="Windows Update" Margin="0,6" Command="{Binding CmdWindowsUpdate}"/>

--- a/src/Virgil.App/Services/CleanOptions.cs
+++ b/src/Virgil.App/Services/CleanOptions.cs
@@ -1,0 +1,9 @@
+namespace Virgil.App.Services;
+
+public class CleanOptions
+{
+    public bool Thumbnails { get; set; } = true;
+    public bool ExplorerCache { get; set; } = true;
+    public bool MruRecent { get; set; } = true;
+    public bool BrowserCookies { get; set; } = false; // optionnel, par défaut off
+}

--- a/src/Virgil.App/Services/CleanStats.cs
+++ b/src/Virgil.App/Services/CleanStats.cs
@@ -1,0 +1,3 @@
+namespace Virgil.App.Services;
+
+public record CleanStats(int Files, int Dirs, long Bytes);

--- a/src/Virgil.App/Services/CleaningService.cs
+++ b/src/Virgil.App/Services/CleaningService.cs
@@ -10,37 +10,72 @@ public class CleaningService : ICleaningService
     public async Task<int> CleanIntelligentAsync(bool dryRun = false)
     {
         int deleted = 0;
-        deleted += await PurgeDir(Path.GetTempPath(), dryRun);
+        deleted += await PurgeDir(Path.GetTempPath(), dryRun).ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
         var winDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-        deleted += await PurgeDir(Path.Combine(winDir, "Temp"), dryRun);
-        deleted += await PurgeDir(Path.Combine(winDir, "Prefetch"), dryRun, pattern: "*.pf");
-        deleted += await PurgeDir(Path.Combine(winDir, "SoftwareDistribution", "Download"), dryRun);
+        deleted += await PurgeDir(Path.Combine(winDir, "Temp"), dryRun).ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
+        deleted += await PurgeDir(Path.Combine(winDir, "Prefetch"), dryRun, pattern: "*.pf").ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
+        deleted += await PurgeDir(Path.Combine(winDir, "SoftwareDistribution", "Download"), dryRun).ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
         var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        deleted += await PurgeDir(Path.Combine(local, "Google", "Chrome", "User Data", "Default", "Cache"), dryRun);
-        deleted += await PurgeDir(Path.Combine(local, "Microsoft", "Edge", "User Data", "Default", "Cache"), dryRun);
+        deleted += await PurgeDir(Path.Combine(local, "Google", "Chrome", "User Data", "Default", "Cache"), dryRun).ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
+        deleted += await PurgeDir(Path.Combine(local, "Microsoft", "Edge", "User Data", "Default", "Cache"), dryRun).ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
         var ffProfiles = Path.Combine(local, "Mozilla", "Firefox", "Profiles");
-        deleted += await PurgeDir(ffProfiles, dryRun, pattern: "*cache*");
+        deleted += await PurgeDir(ffProfiles, dryRun, pattern: "*cache*").ContinueWith(t=>t.Result.Files).ConfigureAwait(false);
         return deleted;
     }
 
-    private static Task<int> PurgeDir(string? path, bool dryRun, string pattern = "*")
+    public async Task<CleanStats> CleanAdvancedAsync(CleanOptions options, bool dryRun = false)
+    {
+        int files = 0, dirs = 0; long bytes = 0;
+        void Acc(CleanStats s) { files += s.Files; dirs += s.Dirs; bytes += s.Bytes; }
+
+        // Corbeille (non géré ici, dépend SHEmptyRecycleBin)
+
+        // Miniatures & cache Explorer
+        if (options.Thumbnails || options.ExplorerCache)
+        {
+            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var explorer = Path.Combine(local, "Microsoft", "Windows", "Explorer");
+            if (options.Thumbnails) Acc(await PurgeDir(explorer, dryRun, pattern: "thumbcache*"));
+            if (options.ExplorerCache) Acc(await PurgeDir(explorer, dryRun, pattern: "iconcache*"));
+        }
+
+        // MRU / Récents
+        if (options.MruRecent)
+        {
+            var app = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var recent = Path.Combine(app, "Microsoft", "Windows", "Recent");
+            Acc(await PurgeDir(recent, dryRun));
+        }
+
+        // Cookies navigateurs (optionnelle, par défaut faux) — non destructive si off
+        if (options.BrowserCookies)
+        {
+            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            Acc(await PurgeDir(Path.Combine(local, "Google", "Chrome", "User Data", "Default", "Cookies"), dryRun));
+            Acc(await PurgeDir(Path.Combine(local, "Microsoft", "Edge", "User Data", "Default", "Cookies"), dryRun));
+        }
+
+        return new CleanStats(files, dirs, bytes);
+    }
+
+    private static Task<CleanStats> PurgeDir(string? path, bool dryRun, string pattern = "*")
     {
         return Task.Run(() =>
         {
-            if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path)) return 0;
-            int count = 0;
+            if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path)) return new CleanStats(0,0,0);
+            int f = 0, d = 0; long b = 0;
             try
             {
-                foreach (var file in Directory.EnumerateFiles(path, pattern, SearchOption.AllDirectories))
+                foreach (var file in Directory.EnumerateFiles(path, pattern, SearchOption.TopDirectoryOnly))
                 {
-                    try { if (!dryRun) File.Delete(file); count++; } catch { }
+                    try { var fi = new FileInfo(file); b += fi.Exists ? fi.Length : 0; if (!dryRun) fi.Delete(); f++; } catch { }
                 }
-                foreach (var dir in Directory.EnumerateDirectories(path, "*", SearchOption.AllDirectories).OrderByDescending(d => d.Length))
+                foreach (var dir in Directory.EnumerateDirectories(path, pattern, SearchOption.TopDirectoryOnly).OrderByDescending(x => x.Length))
                 {
-                    try { if (!dryRun) Directory.Delete(dir, false); } catch { }
+                    try { if (!dryRun) Directory.Delete(dir, true); d++; } catch { }
                 }
             } catch { }
-            return count;
+            return new CleanStats(f,d,b);
         });
     }
 }

--- a/src/Virgil.App/Services/ICleaningService.cs
+++ b/src/Virgil.App/Services/ICleaningService.cs
@@ -5,4 +5,5 @@ namespace Virgil.App.Services;
 public interface ICleaningService
 {
     Task<int> CleanIntelligentAsync(bool dryRun = false);
+    Task<CleanStats> CleanAdvancedAsync(CleanOptions options, bool dryRun = false);
 }


### PR DESCRIPTION
Ajouts:
- **CleanOptions / CleanStats** : options et stats structurées (fichiers, dossiers, octets).
- **CleaningService.CleanAdvancedAsync(options, dryRun)** :
  - Miniatures (`thumbcache*`), cache Explorer (`iconcache*`), MRU/Récents.
  - Cookies navigateurs (option OFF par défaut).
  - Comptage d’octets supprimés.
- **UI/VM** : bouton *Nettoyage avancé*, message avec total en Mo, log JSON enrichi.

Notes:
- Corbeille non incluse (prévoir `SHEmptyRecycleBin` plus tard).
- Wsreset et autres actions système resteront dans la passe suivante (contrôles + garde-fous).

Étape d’après suggérée :
- Panneau d’options (toggle cookies/MRU/etc.), wsreset, thumbnail rebuild, et récap HTML des tailles gagnées.