### PR TITLE
Phase 8: Options persistantes + actions système (wsreset, rebuild caches, vider Corbeille)

### DIFF
--- a/src/Virgil.App/MainWindow.xaml
+++ b/src/Virgil.App/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Virgil.App.Controls"
-        Title="Virgil" Height="750" Width="1120" MinHeight="560" MinWidth="900" Background="#0E0E10">
+        Title="Virgil" Height="760" Width="1140" MinHeight="560" MinWidth="900" Background="#0E0E10">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="48"/>
@@ -21,7 +21,7 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="300"/>
                 <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="360"/>
+                <ColumnDefinition Width="380"/>
             </Grid.ColumnDefinitions>
 
             <Border Background="#141418" CornerRadius="8" Padding="14" Margin="0,0,10,0">
@@ -55,6 +55,16 @@
                     <Button Content="Maintenance complète" Margin="0,6" Command="{Binding CmdMaintenanceAll}"/>
                     <Button Content="Nettoyage intelligent" Margin="0,6" Command="{Binding CmdCleanSmart}"/>
                     <Button Content="Nettoyage avancé" Margin="0,6" Command="{Binding CmdCleanAdvanced}"/>
+                    <Separator/>
+                    <TextBlock Text="Système" FontWeight="SemiBold" Foreground="#E6E6E6"/>
+                    <Button Content="Réinitialiser Microsoft Store (wsreset)" Margin="0,6" Command="{Binding CmdWsReset}"/>
+                    <Button Content="Reconstruire miniatures/icônes" Margin="0,6" Command="{Binding CmdRebuildCaches}"/>
+                    <Button Content="Vider la Corbeille" Margin="0,6" Command="{Binding CmdEmptyRecycleBin}"/>
+                    <Separator/>
+                    <TextBlock Text="Configuration" FontWeight="SemiBold" Foreground="#E6E6E6"/>
+                    <Button Content="Ouvrir Options" Margin="0,6" Command="{Binding CmdOpenOptions}"/>
+                    <Separator/>
+                    <TextBlock Text="Mises à jour" FontWeight="SemiBold" Foreground="#E6E6E6"/>
                     <Button Content="Tout mettre à jour (winget)" Margin="0,6" Command="{Binding CmdWingetUpgrade}"/>
                     <Button Content="Apps Microsoft Store" Margin="0,6" Command="{Binding CmdStoreUpdate}"/>
                     <Button Content="Windows Update" Margin="0,6" Command="{Binding CmdWindowsUpdate}"/>

--- a/src/Virgil.App/Services/ISettingsService.cs
+++ b/src/Virgil.App/Services/ISettingsService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Virgil.App.Services;
+
+public interface ISettingsService
+{
+    Task<CleanOptions> LoadAsync();
+    Task SaveAsync(CleanOptions options);
+}

--- a/src/Virgil.App/Services/ISystemActionsService.cs
+++ b/src/Virgil.App/Services/ISystemActionsService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace Virgil.App.Services;
+
+public interface ISystemActionsService
+{
+    Task<int> WsResetAsync();
+    Task<int> RebuildExplorerCachesAsync();
+    Task<int> EmptyRecycleBinAsync();
+}

--- a/src/Virgil.App/Services/JsonSettingsService.cs
+++ b/src/Virgil.App/Services/JsonSettingsService.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Virgil.App.Services;
+
+public class JsonSettingsService : ISettingsService
+{
+    private readonly string _path;
+    public JsonSettingsService()
+    {
+        var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Virgil");
+        Directory.CreateDirectory(dir);
+        _path = Path.Combine(dir, "settings.json");
+    }
+    public async Task<CleanOptions> LoadAsync()
+    {
+        try
+        {
+            if (!File.Exists(_path)) return new CleanOptions();
+            var json = await File.ReadAllTextAsync(_path);
+            return JsonSerializer.Deserialize<CleanOptions>(json) ?? new CleanOptions();
+        } catch { return new CleanOptions(); }
+    }
+    public async Task SaveAsync(CleanOptions options)
+    {
+        var json = JsonSerializer.Serialize(options, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(_path, json);
+    }
+}

--- a/src/Virgil.App/Services/SystemActionsService.cs
+++ b/src/Virgil.App/Services/SystemActionsService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Virgil.App.Services;
+
+public class SystemActionsService : ISystemActionsService
+{
+    [Flags] private enum RecycleFlags : int { SHERB_NOCONFIRMATION = 0x00000001, SHERB_NOPROGRESSUI = 0x00000002, SHERB_NOSOUND = 0x00000004 }
+    [DllImport("Shell32.dll", CharSet = CharSet.Unicode)]
+    private static extern int SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, RecycleFlags dwFlags);
+
+    private readonly IProcessRunner _runner = new ProcessRunner();
+
+    public Task<int> WsResetAsync() => _runner.RunAsync("wsreset.exe", string.Empty, elevate:true);
+
+    public Task<int> RebuildExplorerCachesAsync()
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                var explorer = Path.Combine(local, "Microsoft", "Windows", "Explorer");
+                if (Directory.Exists(explorer))
+                {
+                    foreach (var file in Directory.GetFiles(explorer, "thumbcache*")) { try { File.Delete(file); } catch {} }
+                    foreach (var file in Directory.GetFiles(explorer, "iconcache*"))  { try { File.Delete(file); } catch {} }
+                }
+                return 0;
+            }
+            catch { return 1; }
+        });
+    }
+
+    public Task<int> EmptyRecycleBinAsync()
+    {
+        return Task.Run(() =>
+        {
+            try { return SHEmptyRecycleBin(IntPtr.Zero, null!, RecycleFlags.SHERB_NOCONFIRMATION | RecycleFlags.SHERB_NOPROGRESSUI | RecycleFlags.SHERB_NOSOUND); }
+            catch { return 1; }
+        });
+    }
+}

--- a/src/Virgil.App/ViewModels/MainViewModel.cs
+++ b/src/Virgil.App/ViewModels/MainViewModel.cs
@@ -9,6 +9,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Virgil.App.Infrastructure;
 using Virgil.App.Services;
+using Virgil.App.Views;
 
 namespace Virgil.App.ViewModels;
 
@@ -20,6 +21,8 @@ public class MainViewModel : INotifyPropertyChanged
     private readonly ICleaningService _clean = new CleaningService();
     private readonly IStoreService _store = new StoreService(new ProcessRunner());
     private readonly IDriverService _drivers = new DriverService(new ProcessRunner());
+    private readonly ISettingsService _settings = new JsonSettingsService();
+    private readonly ISystemActionsService _sys = new SystemActionsService();
     private readonly IFileLogger _log = new FileLogger();
     private readonly IJsonLogger _jlog = new JsonFileLogger();
 
@@ -49,11 +52,10 @@ public class MainViewModel : INotifyPropertyChanged
     public ICommand CmdMaintenanceAll   => new SimpleCommand(async () => await DoMaintenanceAll());
     public ICommand CmdCleanSmart       => new SimpleCommand(async () => await DoCleanSmart());
     public ICommand CmdCleanAdvanced    => new SimpleCommand(async () => await DoCleanAdvanced());
-    public ICommand CmdWingetUpgrade    => new SimpleCommand(async () => await DoWinget());
-    public ICommand CmdStoreUpdate      => new SimpleCommand(async () => await DoStore());
-    public ICommand CmdWindowsUpdate    => new SimpleCommand(async () => await DoWU());
-    public ICommand CmdDefenderUpdate   => new SimpleCommand(async () => await DoDef());
-    public ICommand CmdDriversUpdate    => new SimpleCommand(async () => await DoDrivers());
+    public ICommand CmdOpenOptions      => new SimpleCommand(() => OpenOptions());
+    public ICommand CmdWsReset          => new SimpleCommand(async () => await DoWsReset());
+    public ICommand CmdRebuildCaches    => new SimpleCommand(async () => await DoRebuildCaches());
+    public ICommand CmdEmptyRecycleBin  => new SimpleCommand(async () => await DoEmptyRecycleBin());
 
     private static string MoodToFile(Mood m) => m switch
     {
@@ -72,36 +74,28 @@ public class MainViewModel : INotifyPropertyChanged
 
     public MainViewModel()
     {
-        Messages.Add("Virgil prêt. Nettoyage avancé dispo.");
+        Messages.Add("Virgil prêt. Options + actions système.");
         _timer.Tick += (_, _) => { OnTick(); OnPropertyChanged(nameof(Now)); };
         _timer.Start();
     }
 
-    private void OnTick()
-    {
-        var m = _mon.Read();
-        CpuUsage = m.Cpu;
-        RamUsage = m.Ram;
-        CpuTemp = m.CpuTemp;
-    }
-
-    private void UpdateMood()
-    {
-        if (CpuTemp > 80 || CpuUsage > 90 || RamUsage > 90) Mood = Mood.Alert;
-        else if (CpuUsage > 70 || RamUsage > 80) Mood = Mood.Warn;
-        else if (CpuUsage > 35) Mood = Mood.Focused;
-        else Mood = Mood.Happy;
-    }
+    private void OnTick(){ var m=_mon.Read(); CpuUsage=m.Cpu; RamUsage=m.Ram; CpuTemp=m.CpuTemp; }
+    private void UpdateMood(){ if (CpuTemp>80||CpuUsage>90||RamUsage>90) Mood=Mood.Alert; else if (CpuUsage>70||RamUsage>80) Mood=Mood.Warn; else if (CpuUsage>35) Mood=Mood.Focused; else Mood=Mood.Happy; }
 
     private async Task DoMaintenanceAll(){ await DoCleanSmart(); await DoWinget(); await DoStore(); await DoWU(); await DoDef(); await DoDrivers(); }
     private async Task DoCleanSmart(){ var n = await _clean.CleanIntelligentAsync(); Messages.Add($"Fichiers supprimés: {n}."); _jlog.Write(new { op="clean", files=n }); }
-    private async Task DoCleanAdvanced(){ var s = await _clean.CleanAdvancedAsync(new CleanOptions()); Messages.Add($"Avancé: fichiers {s.Files}, dossiers {s.Dirs}, ~{s.Bytes/1024/1024} Mo."); _jlog.Write(new { op="clean-advanced", files=s.Files, dirs=s.Dirs, bytes=s.Bytes }); }
+    private async Task DoCleanAdvanced(){ var opt = await _settings.LoadAsync(); var s = await _clean.CleanAdvancedAsync(opt); Messages.Add($"Avancé: fichiers {s.Files}, dossiers {s.Dirs}, ~{s.Bytes/1024/1024} Mo."); _jlog.Write(new { op="clean-advanced", files=s.Files, dirs=s.Dirs, bytes=s.Bytes }); }
+
+    private void OpenOptions(){ var w = new OptionsWindow(); w.ShowDialog(); }
+    private async Task DoWsReset(){ var code = await _sys.WsResetAsync(); Messages.Add(code==0?"Store reset OK.":$"wsreset code {code}."); }
+    private async Task DoRebuildCaches(){ var code = await _sys.RebuildExplorerCachesAsync(); Messages.Add(code==0?"Caches Explorer nettoyés.":$"Rebuild caches code {code}."); }
+    private async Task DoEmptyRecycleBin(){ var code = await _sys.EmptyRecycleBinAsync(); Messages.Add(code==0?"Corbeille vidée.":$"RecycleBin code {code}."); }
+
     private async Task DoStore(){ var code = await _store.UpdateStoreAppsAsync(); Messages.Add(code==0?"Store OK.":$"Store code {code}."); }
     private async Task DoDrivers(){ var b=System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),"Virgil","drivers-backup"); await _drivers.BackupDriversAsync(b); var code=await _drivers.ScanAndUpdateDriversAsync(); Messages.Add(code==0?"Pilotes: OK.":$"Pilotes code {code}."); }
     private async Task DoWinget(){ var code = await _ops.RunWingetUpgradeAsync(); Messages.Add(code==0?"Mises à jour apps/jeux OK.":$"Winget code {code}."); }
     private async Task DoWU(){ var code = await _ops.RunWindowsUpdateAsync(); Messages.Add(code==0?"Windows Update OK.":$"Windows Update code {code}."); }
     private async Task DoDef(){ var code = await _ops.RunDefenderUpdateAndQuickScanAsync(); Messages.Add(code==0?"Defender OK.":$"Defender code {code}."); }
 
-    private void OnPropertyChanged([CallerMemberName] string? name = null)
-        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }

--- a/src/Virgil.App/ViewModels/OptionsViewModel.cs
+++ b/src/Virgil.App/ViewModels/OptionsViewModel.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Virgil.App.Services;
+
+namespace Virgil.App.ViewModels;
+
+public class OptionsViewModel : INotifyPropertyChanged
+{
+    private readonly ISettingsService _settings = new JsonSettingsService();
+
+    private bool _thumbnails = true;
+    private bool _explorerCache = true;
+    private bool _mruRecent = true;
+    private bool _browserCookies = false;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool Thumbnails { get => _thumbnails; set { _thumbnails = value; OnChanged(); } }
+    public bool ExplorerCache { get => _explorerCache; set { _explorerCache = value; OnChanged(); } }
+    public bool MruRecent { get => _mruRecent; set { _mruRecent = value; OnChanged(); } }
+    public bool BrowserCookies { get => _browserCookies; set { _browserCookies = value; OnChanged(); } }
+
+    public async Task LoadAsync()
+    {
+        var o = await _settings.LoadAsync();
+        Thumbnails = o.Thumbnails; ExplorerCache = o.ExplorerCache; MruRecent = o.MruRecent; BrowserCookies = o.BrowserCookies;
+    }
+
+    public Task SaveAsync() => _settings.SaveAsync(new CleanOptions{ Thumbnails = Thumbnails, ExplorerCache = ExplorerCache, MruRecent = MruRecent, BrowserCookies = BrowserCookies });
+
+    private void OnChanged([CallerMemberName] string? n=null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+}

--- a/src/Virgil.App/Views/OptionsWindow.xaml
+++ b/src/Virgil.App/Views/OptionsWindow.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="Virgil.App.Views.OptionsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Options Virgil" Height="260" Width="420" Background="#141418" Foreground="#E6E6E6" WindowStartupLocation="CenterOwner">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel>
+            <CheckBox Content="Miniatures (thumbcache)" IsChecked="{Binding Thumbnails}" Margin="0,6"/>
+            <CheckBox Content="Cache Explorer (iconcache)" IsChecked="{Binding ExplorerCache}" Margin="0,6"/>
+            <CheckBox Content="Récents/MRU" IsChecked="{Binding MruRecent}" Margin="0,6"/>
+            <CheckBox Content="Cookies navigateurs" IsChecked="{Binding BrowserCookies}" Margin="0,6"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Annuler" Width="100" Margin="0,0,8,0" IsCancel="True"/>
+            <Button Content="Enregistrer" Width="120" IsDefault="True" Click="OnSave"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/Virgil.App/Views/OptionsWindow.xaml.cs
+++ b/src/Virgil.App/Views/OptionsWindow.xaml.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using System.Windows;
+using Virgil.App.ViewModels;
+
+namespace Virgil.App.Views;
+
+public partial class OptionsWindow : Window
+{
+    private readonly OptionsViewModel _vm = new();
+    public OptionsWindow()
+    {
+        InitializeComponent();
+        DataContext = _vm;
+        Loaded += async (_, __) => await _vm.LoadAsync();
+    }
+    private async void OnSave(object sender, RoutedEventArgs e)
+    {
+        await _vm.SaveAsync();
+        DialogResult = true;
+        Close();
+    }
+}


### PR DESCRIPTION
### Nouveau
- **Options persistantes** (JSON): `ISettingsService` + `JsonSettingsService` (stockées dans %AppData%/Virgil/settings.json).
- **Fenêtre Options** (`OptionsWindow`) + `OptionsViewModel`: toggles pour *Miniatures*, *Cache Explorer*, *Récents/MRU*, *Cookies navigateurs*.
- **Actions système** (`ISystemActionsService` + `SystemActionsService`) :
  - `wsreset` (réinit Microsoft Store),
  - reconstruction miniatures/icônes (suppression `thumbcache*`/`iconcache*`),
  - **vider la Corbeille** via `SHEmptyRecycleBin` (silencieux).
- **Intégration UI/VM**: nouveaux boutons (Options, wsreset, rebuild caches, vider Corbeille) et usage des options sauvegardées pour *Nettoyage avancé*.

### Notes
- Garde-fous: pas de redémarrage d'Explorer forcé ici (safe by default).
- Tout est journalisé côté chat + JSON.

Étapes suivantes: panneau Options étendu (réseau/DNS, planif), drivers OEM (Intel/AMD/NVIDIA), rapport HTML enrichi (tailles gagnées/durées).