### PR TITLE
Phase 8c (rebased): Mode Rambo — rebuild caches + restart Explorer (option + UI)

### DIFF
--- a/src/Virgil.App/MainWindow.xaml
+++ b/src/Virgil.App/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:Virgil.App.Controls"
-        Title="Virgil" Height="760" Width="1140" MinHeight="560" MinWidth="900" Background="#0E0E10">
+        Title="Virgil" Height="780" Width="1140" MinHeight="560" MinWidth="900" Background="#0E0E10">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="48"/>
@@ -59,6 +59,7 @@
                     <TextBlock Text="Système" FontWeight="SemiBold" Foreground="#E6E6E6"/>
                     <Button Content="Réinitialiser Microsoft Store (wsreset)" Margin="0,6" Command="{Binding CmdWsReset}"/>
                     <Button Content="Reconstruire miniatures/icônes" Margin="0,6" Command="{Binding CmdRebuildCaches}"/>
+                    <Button Content="Rebuild + Redémarrer Explorer (mode Rambo)" Margin="0,6" Command="{Binding CmdRamboRebuild}"/>
                     <Button Content="Vider la Corbeille" Margin="0,6" Command="{Binding CmdEmptyRecycleBin}"/>
                     <Separator/>
                     <TextBlock Text="Configuration" FontWeight="SemiBold" Foreground="#E6E6E6"/>

--- a/src/Virgil.App/Services/CleanOptions.cs
+++ b/src/Virgil.App/Services/CleanOptions.cs
@@ -5,5 +5,6 @@ public class CleanOptions
     public bool Thumbnails { get; set; } = true;
     public bool ExplorerCache { get; set; } = true;
     public bool MruRecent { get; set; } = true;
-    public bool BrowserCookies { get; set; } = false; // optionnel, par défaut off
+    public bool BrowserCookies { get; set; } = false;
+    public bool RestartExplorerAfterRebuild { get; set; } = false;
 }

--- a/src/Virgil.App/Services/ISystemActionsService.cs
+++ b/src/Virgil.App/Services/ISystemActionsService.cs
@@ -7,4 +7,6 @@ public interface ISystemActionsService
     Task<int> WsResetAsync();
     Task<int> RebuildExplorerCachesAsync();
     Task<int> EmptyRecycleBinAsync();
+    Task<int> RestartExplorerAsync();
+    Task<int> RebuildExplorerCachesAndRestartAsync();
 }

--- a/src/Virgil.App/ViewModels/MainViewModel.cs
+++ b/src/Virgil.App/ViewModels/MainViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -47,55 +48,46 @@ public class MainViewModel : INotifyPropertyChanged
     public Mood Mood { get => _mood; set { _mood = value; OnPropertyChanged(); OnPropertyChanged(nameof(MoodColor)); OnPropertyChanged(nameof(AvatarSource)); } }
 
     public SolidColorBrush MoodColor => MoodPalette.For(Mood);
-    public System.Windows.Media.ImageSource AvatarSource => new BitmapImage(new Uri($"pack://application:,,,/assets/avatar/{MoodToFile(Mood)}"));
+    public ImageSource AvatarSource => new BitmapImage(new Uri($"pack://application:,,,/assets/avatar/{MoodToFile(Mood)}"));
 
-    public ICommand CmdMaintenanceAll   => new SimpleCommand(async () => await DoMaintenanceAll());
-    public ICommand CmdCleanSmart       => new SimpleCommand(async () => await DoCleanSmart());
-    public ICommand CmdCleanAdvanced    => new SimpleCommand(async () => await DoCleanAdvanced());
-    public ICommand CmdOpenOptions      => new SimpleCommand(() => OpenOptions());
-    public ICommand CmdWsReset          => new SimpleCommand(async () => await DoWsReset());
-    public ICommand CmdRebuildCaches    => new SimpleCommand(async () => await DoRebuildCaches());
-    public ICommand CmdEmptyRecycleBin  => new SimpleCommand(async () => await DoEmptyRecycleBin());
+    public ICommand CmdMaintenanceAll=> new SimpleCommand(async()=>await DoMaintenanceAll());
+    public ICommand CmdCleanSmart    => new SimpleCommand(async()=>await DoCleanSmart());
+    public ICommand CmdCleanAdvanced => new SimpleCommand(async()=>await DoCleanAdvanced());
+    public ICommand CmdOpenOptions   => new SimpleCommand(()=> OpenOptions());
+    public ICommand CmdWsReset       => new SimpleCommand(async()=>await DoWsReset());
+    public ICommand CmdRebuildCaches => new SimpleCommand(async()=>await DoRebuildCaches());
+    public ICommand CmdEmptyRecycleBin=>new SimpleCommand(async()=>await DoEmptyRecycleBin());
+    public ICommand CmdRamboRebuild  => new SimpleCommand(async()=>await DoRamboRebuild());
+    public ICommand CmdWingetUpgrade => new SimpleCommand(async()=>await DoWinget());
+    public ICommand CmdStoreUpdate   => new SimpleCommand(async()=>await DoStore());
+    public ICommand CmdWindowsUpdate => new SimpleCommand(async()=>await DoWU());
+    public ICommand CmdDefenderUpdate=> new SimpleCommand(async()=>await DoDef());
+    public ICommand CmdDriversUpdate => new SimpleCommand(async()=>await DoDrivers());
 
-    private static string MoodToFile(Mood m) => m switch
-    {
-        Mood.Happy   => "happy.png",
-        Mood.Focused => "focused.png",
-        Mood.Warn    => "warn.png",
-        Mood.Alert   => "alert.png",
-        Mood.Proud   => "proud.png",
-        Mood.Tired   => "tired.png",
-        Mood.Angry   => "angry.png",
-        Mood.Love    => "love.png",
-        Mood.Chat    => "chat.png",
-        Mood.Sleepy  => "sleepy.png",
-        _            => "neutral.png"
-    };
+    private static string MoodToFile(Mood m)=> m switch{
+        Mood.Happy=>"happy.png", Mood.Focused=>"focused.png", Mood.Warn=>"warn.png", Mood.Alert=>"alert.png",
+        Mood.Proud=>"proud.png", Mood.Tired=>"tired.png", Mood.Angry=>"angry.png", Mood.Love=>"love.png",
+        Mood.Chat=>"chat.png", Mood.Sleepy=>"sleepy.png", _=>"neutral.png"};
 
-    public MainViewModel()
-    {
-        Messages.Add("Virgil prêt. Options + actions système.");
-        _timer.Tick += (_, _) => { OnTick(); OnPropertyChanged(nameof(Now)); };
-        _timer.Start();
-    }
+    public MainViewModel(){ Messages.Add("Virgil prêt. Mode Rambo dispo (option)."); _timer.Tick+=(_,_)=>{var m=_mon.Read(); CpuUsage=m.Cpu; RamUsage=m.Ram; CpuTemp=m.CpuTemp; OnPropertyChanged(nameof(Now));}; _timer.Start(); }
 
-    private void OnTick(){ var m=_mon.Read(); CpuUsage=m.Cpu; RamUsage=m.Ram; CpuTemp=m.CpuTemp; }
-    private void UpdateMood(){ if (CpuTemp>80||CpuUsage>90||RamUsage>90) Mood=Mood.Alert; else if (CpuUsage>70||RamUsage>80) Mood=Mood.Warn; else if (CpuUsage>35) Mood=Mood.Focused; else Mood=Mood.Happy; }
+    private void UpdateMood(){ if(CpuTemp>80||CpuUsage>90||RamUsage>90) Mood=Mood.Alert; else if(CpuUsage>70||RamUsage>80) Mood=Mood.Warn; else if(CpuUsage>35) Mood=Mood.Focused; else Mood=Mood.Happy; }
 
     private async Task DoMaintenanceAll(){ await DoCleanSmart(); await DoWinget(); await DoStore(); await DoWU(); await DoDef(); await DoDrivers(); }
-    private async Task DoCleanSmart(){ var n = await _clean.CleanIntelligentAsync(); Messages.Add($"Fichiers supprimés: {n}."); _jlog.Write(new { op="clean", files=n }); }
-    private async Task DoCleanAdvanced(){ var opt = await _settings.LoadAsync(); var s = await _clean.CleanAdvancedAsync(opt); Messages.Add($"Avancé: fichiers {s.Files}, dossiers {s.Dirs}, ~{s.Bytes/1024/1024} Mo."); _jlog.Write(new { op="clean-advanced", files=s.Files, dirs=s.Dirs, bytes=s.Bytes }); }
+    private async Task DoCleanSmart(){ var n=await _clean.CleanIntelligentAsync(); Messages.Add($"Fichiers supprimés: {n}."); _jlog.Write(new{op="clean",files=n}); }
+    private async Task DoCleanAdvanced(){ var opt=await _settings.LoadAsync(); var s=await _clean.CleanAdvancedAsync(opt); Messages.Add($"Avancé: fichiers {s.Files}, dossiers {s.Dirs}, ~{s.Bytes/1024/1024} Mo."); _jlog.Write(new{op="clean-advanced",files=s.Files,dirs=s.Dirs,bytes=s.Bytes}); }
 
-    private void OpenOptions(){ var w = new OptionsWindow(); w.ShowDialog(); }
-    private async Task DoWsReset(){ var code = await _sys.WsResetAsync(); Messages.Add(code==0?"Store reset OK.":$"wsreset code {code}."); }
-    private async Task DoRebuildCaches(){ var code = await _sys.RebuildExplorerCachesAsync(); Messages.Add(code==0?"Caches Explorer nettoyés.":$"Rebuild caches code {code}."); }
-    private async Task DoEmptyRecycleBin(){ var code = await _sys.EmptyRecycleBinAsync(); Messages.Add(code==0?"Corbeille vidée.":$"RecycleBin code {code}."); }
+    private void OpenOptions(){ var w=new OptionsWindow(); w.ShowDialog(); }
+    private async Task DoWsReset(){ var code=await _sys.WsResetAsync(); Messages.Add(code==0?"Store reset OK.":$"wsreset code {code}."); }
+    private async Task DoRebuildCaches(){ var code=await _sys.RebuildExplorerCachesAsync(); Messages.Add(code==0?"Caches Explorer nettoyés.":$"Rebuild caches code {code}."); }
+    private async Task DoEmptyRecycleBin(){ var code=await _sys.EmptyRecycleBinAsync(); Messages.Add(code==0?"Corbeille vidée.":$"RecycleBin code {code}."); }
+    private async Task DoRamboRebuild(){ var opt=await _settings.LoadAsync(); if(!opt.RestartExplorerAfterRebuild){ MessageBox.Show("Active d'abord l'option Rambo (Options).", "Virgil"); return;} var code=await _sys.RebuildExplorerCachesAndRestartAsync(); Messages.Add(code==0?"Caches nettoyés + Explorer relancé.":$"Rambo code {code}."); }
 
-    private async Task DoStore(){ var code = await _store.UpdateStoreAppsAsync(); Messages.Add(code==0?"Store OK.":$"Store code {code}."); }
+    private async Task DoStore(){ var code=await _store.UpdateStoreAppsAsync(); Messages.Add(code==0?"Store OK.":$"Store code {code}."); }
     private async Task DoDrivers(){ var b=System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),"Virgil","drivers-backup"); await _drivers.BackupDriversAsync(b); var code=await _drivers.ScanAndUpdateDriversAsync(); Messages.Add(code==0?"Pilotes: OK.":$"Pilotes code {code}."); }
-    private async Task DoWinget(){ var code = await _ops.RunWingetUpgradeAsync(); Messages.Add(code==0?"Mises à jour apps/jeux OK.":$"Winget code {code}."); }
-    private async Task DoWU(){ var code = await _ops.RunWindowsUpdateAsync(); Messages.Add(code==0?"Windows Update OK.":$"Windows Update code {code}."); }
-    private async Task DoDef(){ var code = await _ops.RunDefenderUpdateAndQuickScanAsync(); Messages.Add(code==0?"Defender OK.":$"Defender code {code}."); }
+    private async Task DoWinget(){ var code=await _ops.RunWingetUpgradeAsync(); Messages.Add(code==0?"Mises à jour apps/jeux OK.":$"Winget code {code}."); }
+    private async Task DoWU(){ var code=await _ops.RunWindowsUpdateAsync(); Messages.Add(code==0?"Windows Update OK.":$"Windows Update code {code}."); }
+    private async Task DoDef(){ var code=await _ops.RunDefenderUpdateAndQuickScanAsync(); Messages.Add(code==0?"Defender OK.":$"Defender code {code}."); }
 
-    private void OnPropertyChanged([CallerMemberName] string? name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    private void OnPropertyChanged([CallerMemberName] string? name=null)=>PropertyChanged?.Invoke(this,new PropertyChangedEventArgs(name));
 }

--- a/src/Virgil.App/ViewModels/OptionsViewModel.cs
+++ b/src/Virgil.App/ViewModels/OptionsViewModel.cs
@@ -13,6 +13,7 @@ public class OptionsViewModel : INotifyPropertyChanged
     private bool _explorerCache = true;
     private bool _mruRecent = true;
     private bool _browserCookies = false;
+    private bool _rambo = false;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -20,14 +21,10 @@ public class OptionsViewModel : INotifyPropertyChanged
     public bool ExplorerCache { get => _explorerCache; set { _explorerCache = value; OnChanged(); } }
     public bool MruRecent { get => _mruRecent; set { _mruRecent = value; OnChanged(); } }
     public bool BrowserCookies { get => _browserCookies; set { _browserCookies = value; OnChanged(); } }
+    public bool RestartExplorerAfterRebuild { get => _rambo; set { _rambo = value; OnChanged(); } }
 
-    public async Task LoadAsync()
-    {
-        var o = await _settings.LoadAsync();
-        Thumbnails = o.Thumbnails; ExplorerCache = o.ExplorerCache; MruRecent = o.MruRecent; BrowserCookies = o.BrowserCookies;
-    }
+    public async Task LoadAsync(){ var o = await _settings.LoadAsync(); Thumbnails=o.Thumbnails; ExplorerCache=o.ExplorerCache; MruRecent=o.MruRecent; BrowserCookies=o.BrowserCookies; RestartExplorerAfterRebuild=o.RestartExplorerAfterRebuild; }
+    public Task SaveAsync()=> _settings.SaveAsync(new CleanOptions{ Thumbnails=Thumbnails, ExplorerCache=ExplorerCache, MruRecent=MruRecent, BrowserCookies=BrowserCookies, RestartExplorerAfterRebuild=RestartExplorerAfterRebuild });
 
-    public Task SaveAsync() => _settings.SaveAsync(new CleanOptions{ Thumbnails = Thumbnails, ExplorerCache = ExplorerCache, MruRecent = MruRecent, BrowserCookies = BrowserCookies });
-
-    private void OnChanged([CallerMemberName] string? n=null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+    private void OnChanged([CallerMemberName] string? n=null) => PropertyChanged?.Invoke(this,new PropertyChangedEventArgs(n));
 }

--- a/src/Virgil.App/Views/OptionsWindow.xaml
+++ b/src/Virgil.App/Views/OptionsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="Virgil.App.Views.OptionsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Options Virgil" Height="260" Width="420" Background="#141418" Foreground="#E6E6E6" WindowStartupLocation="CenterOwner">
+        Title="Options Virgil" Height="300" Width="460" Background="#141418" Foreground="#E6E6E6" WindowStartupLocation="CenterOwner">
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -12,6 +12,9 @@
             <CheckBox Content="Cache Explorer (iconcache)" IsChecked="{Binding ExplorerCache}" Margin="0,6"/>
             <CheckBox Content="Récents/MRU" IsChecked="{Binding MruRecent}" Margin="0,6"/>
             <CheckBox Content="Cookies navigateurs" IsChecked="{Binding BrowserCookies}" Margin="0,6"/>
+            <Separator/>
+            <CheckBox Content="Mode “Rambo” : redémarrer Explorer après rebuild" IsChecked="{Binding RestartExplorerAfterRebuild}" Margin="0,6"/>
+            <TextBlock Text="(ferme et relance explorer.exe pour reconstruire les caches tout de suite)" FontSize="11" Foreground="#AFAFAF"/>
         </StackPanel>
         <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
             <Button Content="Annuler" Width="100" Margin="0,0,8,0" IsCancel="True"/>

--- a/src/Virgil.App/Views/OptionsWindow.xaml.cs
+++ b/src/Virgil.App/Views/OptionsWindow.xaml.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using System.Windows;
 using Virgil.App.ViewModels;
 
@@ -7,16 +6,6 @@ namespace Virgil.App.Views;
 public partial class OptionsWindow : Window
 {
     private readonly OptionsViewModel _vm = new();
-    public OptionsWindow()
-    {
-        InitializeComponent();
-        DataContext = _vm;
-        Loaded += async (_, __) => await _vm.LoadAsync();
-    }
-    private async void OnSave(object sender, RoutedEventArgs e)
-    {
-        await _vm.SaveAsync();
-        DialogResult = true;
-        Close();
-    }
+    public OptionsWindow(){ InitializeComponent(); DataContext=_vm; Loaded+=async(_,__)=> await _vm.LoadAsync(); }
+    private async void OnSave(object sender, RoutedEventArgs e){ await _vm.SaveAsync(); DialogResult=true; Close(); }
 }


### PR DESCRIPTION
Rebase propre sur `main` pour le **mode Rambo** (zéro conflit).

### Contenu
- **Options**: flag `RestartExplorerAfterRebuild` (OFF par défaut), persistant via settings JSON.
- **Actions système**: `RestartExplorerAsync()` et combo `RebuildExplorerCachesAndRestartAsync()`.
- **UI/VM**: bouton **Rebuild + Redémarrer Explorer (mode Rambo)**, commandes liées, et fenêtre Options mise à jour.
- **Safe by default**: pas d’auto-restart sans opt-in. Messages clairs dans le chat.

À merger, puis activer l’option dans **Options** pour utiliser le bouton Rambo.
