### PR TITLE
Restauration — fondations (Chat + TTL 60s + PhraseEngine skeleton)

### DIFF
--- a/src/Virgil.App/Chat/ChatMessage.cs
+++ b/src/Virgil.App/Chat/ChatMessage.cs
@@ -1,0 +1,13 @@
+namespace Virgil.App.Chat;
+
+public enum ChatKind { Info, Progress, Success, Warning, Error }
+
+public sealed class ChatMessage
+{
+    public Guid Id { get; } = Guid.NewGuid();
+    public DateTime CreatedAt { get; } = DateTime.UtcNow;
+    public TimeSpan Ttl { get; init; } = TimeSpan.FromSeconds(60);
+    public string Text { get; init; } = string.Empty;
+    public ChatKind Kind { get; init; } = ChatKind.Info;
+    public int? Progress { get; init; }
+}

--- a/src/Virgil.App/Chat/ChatService.cs
+++ b/src/Virgil.App/Chat/ChatService.cs
@@ -1,0 +1,37 @@
+using System.Collections.ObjectModel;
+using System.Timers;
+
+namespace Virgil.App.Chat;
+
+public sealed class ChatService : IDisposable
+{
+    public ObservableCollection<ChatMessage> Messages { get; } = new();
+    private readonly Timer _gc = new(1000);
+
+    public ChatService()
+    {
+        _gc.Elapsed += (_, _) => Cleanup();
+        _gc.Start();
+    }
+
+    public void Post(string text, ChatKind kind = ChatKind.Info, int? progress = null, int ttlSeconds = 60)
+    {
+        var msg = new ChatMessage { Text = text, Kind = kind, Progress = progress, Ttl = TimeSpan.FromSeconds(ttlSeconds) };
+        App.Current?.Dispatcher.Invoke(() => Messages.Add(msg));
+    }
+
+    private void Cleanup()
+    {
+        var now = DateTime.UtcNow;
+        App.Current?.Dispatcher.Invoke(() =>
+        {
+            for (int i = Messages.Count - 1; i >= 0; i--)
+            {
+                var m = Messages[i];
+                if (now - m.CreatedAt >= m.Ttl) Messages.RemoveAt(i);
+            }
+        });
+    }
+
+    public void Dispose() => _gc.Dispose();
+}

--- a/src/Virgil.App/Chat/PhraseEngine.cs
+++ b/src/Virgil.App/Chat/PhraseEngine.cs
@@ -1,0 +1,24 @@
+namespace Virgil.App.Chat;
+
+public enum PhraseStyle { Pro, Taquin }
+
+public sealed class PhraseEngine
+{
+    private readonly Random _rng = new();
+    public PhraseStyle Style { get; set; } = PhraseStyle.Taquin;
+
+    public string For(string intent, string phase, int? percent = null)
+    {
+        // squelette minimal: on remplira la bibliothèque complète plus tard
+        return (intent, phase) switch
+        {
+            ("clean", "start") => Style == PhraseStyle.Taquin ? "Ok, en avant. J’ouvre les fenêtres." : "Nettoyage intelligent démarré.",
+            ("clean", "progress") when percent.HasValue => Style == PhraseStyle.Taquin ? $"J’en suis à {percent}%…" : $"Progression {percent}%",
+            ("clean", "finish") => Style == PhraseStyle.Taquin ? "Nettoyage terminé. Ton PC respire." : "Nettoyage terminé.",
+            ("update", "start") => Style == PhraseStyle.Taquin ? "Updates en marche. Ne touche à rien." : "Mises à jour démarrées.",
+            ("update", "progress") when percent.HasValue => $"Mises à jour {percent}%",
+            ("update", "finish") => "Mises à jour terminées.",
+            _ => "…"
+        };
+    }
+}

--- a/src/Virgil.App/Converters/NullToVisibilityConverter.cs
+++ b/src/Virgil.App/Converters/NullToVisibilityConverter.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Virgil.App.Converters;
+
+public sealed class NullToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value == null ? Visibility.Collapsed : Visibility.Visible;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}


### PR DESCRIPTION
Première étape de la restauration complète de Virgil.

### Ajouts
- `Chat/ChatMessage.cs` : modèle de bulle avec TTL (60 s par défaut).
- `Chat/ChatService.cs` : service avec timer de purge, thread-safe via Dispatcher.
- `Chat/PhraseEngine.cs` : squelette de moteur de répliques (pro + taquin).
- `Converters/NullToVisibilityConverter.cs` : utilitaire WPF pour ProgressBar optionnelle.

### Pourquoi ce batch ?
Mettre en place l’infrastructure de chat + expiration (effet Thanos) et la base des phrases **sans casser l’UI existante**.

### Suites prévues (PR suivantes)
- Brancher MonitoringService + jauges CPU/GPU/RAM/Disque + températures.
- Intégrer Chat à l’UI (ItemsControl + animations entrée/sortie).
- Humeurs avatar + mode taquin + commentaires des actions (start/progress/finish).
- Effet Thanos visuel sur suppression des bulles (fade/translate).