### PR TITLE
feat(ui): Mini HUD + toggle; metrics under avatar (left-aligned) — conflict-free

### DIFF
--- a/src/Virgil.App/Views/MainShell.xaml
+++ b/src/Virgil.App/Views/MainShell.xaml
@@ -5,20 +5,20 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:views="clr-namespace:Virgil.App.Views"
         mc:Ignorable="d"
-        Title="Virgil — Chat + Monitoring" Height="720" Width="780">
+        Title="Virgil — Chat + Monitoring" Height="720" Width="820">
     <DockPanel Background="#0f0f12">
         <ToolBar DockPanel.Dock="Top" Background="#101216" Padding="6">
-            <Button x:Name="BtnSettings" Content="Réglages" Width="100" Click="OnOpenSettings"/>
+            <StackPanel Orientation="Horizontal">
+                <Button x:Name="BtnSettings" Content="Réglages" Width="100" Click="OnOpenSettings"/>
+                <ToggleButton x:Name="BtnHud" Content="Mini HUD" Width="100" Margin="8,0,0,0" IsChecked="True" Checked="OnHudToggled" Unchecked="OnHudToggled"/>
+            </StackPanel>
         </ToolBar>
-
         <views:ActionsPanel x:Name="Actions" DockPanel.Dock="Right" Width="220"/>
-
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="12">
-                <views:AvatarView DataContext="{Binding ElementName=Metrics, Path=DataContext}"
-                                   HorizontalAlignment="Center"/>
-                <!-- Metrics under avatar, left aligned for readability -->
-                <views:MetricsBar x:Name="Metrics" Margin="4,8,0,12" HorizontalAlignment="Left"/>
+                <views:AvatarView DataContext="{Binding ElementName=Metrics, Path=DataContext}" HorizontalAlignment="Center"/>
+                <views:MiniHud x:Name="Hud" DataContext="{Binding ElementName=Metrics, Path=DataContext}" Margin="0,8,0,6"/>
+                <views:MetricsBar x:Name="Metrics" Margin="4,0,0,12" HorizontalAlignment="Left"/>
                 <views:ChatView x:Name="Chat"/>
             </StackPanel>
         </ScrollViewer>

--- a/src/Virgil.App/Views/MainShell.xaml.cs
+++ b/src/Virgil.App/Views/MainShell.xaml.cs
@@ -57,5 +57,10 @@ namespace Virgil.App.Views
                 _chat.Post("Réglages appliqués", MessageType.Success, ttlMs: 3000);
             }
         }
+
+        private void OnHudToggled(object sender, RoutedEventArgs e)
+        {
+            Hud.Visibility = BtnHud.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        }
     }
 }

--- a/src/Virgil.App/Views/MiniHud.xaml
+++ b/src/Virgil.App/Views/MiniHud.xaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="Virgil.App.Views.MiniHud"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Height="Auto" Width="Auto">
+  <StackPanel Orientation="Vertical" Margin="0,0,0,8">
+    <StackPanel Orientation="Horizontal" Margin="0,2">
+      <TextBlock Text="CPU" Width="36"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding CpuUsage}" Maximum="100"/>
+      <TextBlock Text="{Binding CpuTemp, StringFormat={}{0:F0}°C}" Margin="8,0,0,0" Width="52"/>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" Margin="0,2">
+      <TextBlock Text="GPU" Width="36"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding GpuUsage}" Maximum="100"/>
+      <TextBlock Text="{Binding GpuTemp, StringFormat={}{0:F0}°C}" Margin="8,0,0,0" Width="52"/>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" Margin="0,2">
+      <TextBlock Text="RAM" Width="36"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding RamUsage}" Maximum="100"/>
+      <TextBlock Text="{Binding RamUsage, StringFormat={}{0:F0}%}" Margin="8,0,0,0" Width="52"/>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" Margin="0,2">
+      <TextBlock Text="Disk" Width="36"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding DiskUsage}" Maximum="100"/>
+      <TextBlock Text="{Binding DiskUsage, StringFormat={}{0:F0}%}" Margin="8,0,0,0" Width="52"/>
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/src/Virgil.App/Views/MiniHud.xaml.cs
+++ b/src/Virgil.App/Views/MiniHud.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows.Controls;
+
+namespace Virgil.App.Views
+{
+    public partial class MiniHud : UserControl
+    {
+        public MiniHud() { InitializeComponent(); }
+    }
+}


### PR DESCRIPTION
Recreated PR #96 on top of current main to avoid conflicts.
- Adds MiniHud component (compact meters for CPU/GPU/RAM/Disk with temps).
- Adds toolbar ToggleButton to show/hide Mini HUD.
- Places Mini HUD under avatar and keeps MetricsBar under avatar (left-aligned) for text values.

This PR supersedes #96 and should merge cleanly.