### PR TITLE
feat(avatar): BeatPulseService + settings flag (EnableBeatPulse)

### DIFF
--- a/src/Virgil.App/Models/AppSettings.cs
+++ b/src/Virgil.App/Models/AppSettings.cs
@@ -5,10 +5,9 @@ namespace Virgil.App.Models
         public int MonitoringIntervalMs { get; set; } = 2000;
         public int DefaultMessageTtlMs { get; set; } = 60000;
         public MoodThreshold Mood { get; set; } = new();
-        // Persist Mini HUD state
         public bool ShowMiniHud { get; set; } = true;
-        // Controls how chatty the companion mode is
         public bool CompanionTalkative { get; set; } = false;
+        public bool EnableBeatPulse { get; set; } = true;
     }
 
     public class MoodThreshold

--- a/src/Virgil.App/Services/BeatPulseService.cs
+++ b/src/Virgil.App/Services/BeatPulseService.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Timers;
+
+namespace Virgil.App.Services
+{
+    public class BeatPulseService : IDisposable
+    {
+        public event Action<double>? Pulse; // intensity 0..1
+        private readonly Timer _t;
+        private readonly Random _rng = new();
+        public BeatPulseService(int baseMs = 900)
+        {
+            _t = new Timer(baseMs) { AutoReset = true };
+            _t.Elapsed += (_, __) =>
+            {
+                // small jitter and gentle intensity
+                var jitter = 0.85 + _rng.NextDouble() * 0.3;
+                _t.Interval = Math.Max(400, baseMs * jitter);
+                Pulse?.Invoke(0.12 + _rng.NextDouble() * 0.08);
+            };
+        }
+        public void Start() => _t.Start();
+        public void Stop() => _t.Stop();
+        public void Dispose() { _t.Dispose(); }
+    }
+}

--- a/src/Virgil.App/Views/MainShell.xaml.cs
+++ b/src/Virgil.App/Views/MainShell.xaml.cs
@@ -16,6 +16,7 @@ namespace Virgil.App.Views
         private readonly ActionsService _actionsSvc = new();
         private readonly ActionsViewModel _actionsVm;
         private readonly PulseController _pulse;
+        private BeatPulseService? _beat;
 
         public MainShell()
         {
@@ -44,6 +45,14 @@ namespace Virgil.App.Views
             {
                 Hud.Visibility = _settings.Settings.ShowMiniHud ? Visibility.Visible : Visibility.Collapsed;
                 BtnHud.IsChecked = _settings.Settings.ShowMiniHud;
+
+                // start beat pulse if enabled
+                if (_settings.Settings.EnableBeatPulse) {
+                    _beat = new BeatPulseService();
+                    _beat.Pulse += v => Dispatcher.Invoke(() => Avatar?.Pulse(v));
+                    _beat.Start();
+                }
+
                 _chat.Post("Virgil est en ligne.");
                 _chat.Post("Surveillance activée.", MessageType.Success, pinned: true);
                 _chat.Post("Petit message éphémère…", MessageType.Info, pinned: false, ttlMs: _settings.Settings.DefaultMessageTtlMs / 20);
@@ -60,6 +69,16 @@ namespace Virgil.App.Views
                 _mood.WarnTemp = _settings.Settings.Mood.WarnTemp;
                 _mood.AlertTemp = _settings.Settings.Mood.AlertTemp;
                 _mood.WarnCpu = _settings.Settings.Mood.WarnCpu;
+
+                // apply beat toggle live
+                if (_settings.Settings.EnableBeatPulse) {
+                    _beat ??= new BeatPulseService();
+                    _beat.Pulse += v => Dispatcher.Invoke(() => Avatar?.Pulse(v));
+                    _beat.Start();
+                } else {
+                    _beat?.Stop();
+                }
+
                 _chat.Post("Réglages appliqués", MessageType.Success, ttlMs: 3000);
             }
         }


### PR DESCRIPTION
- Add BeatPulseService (gentle rhythmic pulse with jitter).
- Add settings flag EnableBeatPulse (default true).
- Wire into MainShell: start on load if enabled, live-apply on Settings dialog OK.
- Reuses Avatar.Pulse pipeline for consistent animation.

No audio capture yet, this is the lightweight beat to keep Virgil alive even without events.