### PR TITLE
feat(settings): UI toggle for EnableBeatPulse + CompanionTalkative

### DIFF
--- a/src/Virgil.App/Views/SettingsWindow.xaml
+++ b/src/Virgil.App/Views/SettingsWindow.xaml
@@ -1,42 +1,31 @@
 <Window x:Class="Virgil.App.Views.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Réglages Virgil" Height="360" Width="420">
-    <Grid Margin="12">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <TextBlock Text="Réglages rapides" FontSize="16" Margin="0,0,0,8"/>
-
-        <StackPanel Grid.Row="1" Margin="0,8,0,8">
-            <StackPanel Orientation="Horizontal" Margin="0,4">
-                <TextBlock Width="180" VerticalAlignment="Center" Text="Intervalle monitoring (ms)"/>
-                <TextBox Width="100" Text="{Binding MonitoringIntervalMs}"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,4">
-                <TextBlock Width="180" VerticalAlignment="Center" Text="TTL messages (ms)"/>
-                <TextBox Width="100" Text="{Binding DefaultMessageTtlMs}"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,4">
-                <TextBlock Width="180" VerticalAlignment="Center" Text="Seuil Warn Temp (°C)"/>
-                <TextBox Width="100" Text="{Binding WarnTemp}"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,4">
-                <TextBlock Width="180" VerticalAlignment="Center" Text="Seuil Alert Temp (°C)"/>
-                <TextBox Width="100" Text="{Binding AlertTemp}"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,4">
-                <TextBlock Width="180" VerticalAlignment="Center" Text="Seuil Warn CPU (%)"/>
-                <TextBox Width="100" Text="{Binding WarnCpu}"/>
-            </StackPanel>
-            <CheckBox Margin="0,8,0,0" Content="Compagnon bavard" IsChecked="{Binding CompanionTalkative}"/>
+        Title="Réglages" Height="360" Width="420">
+    <DockPanel Margin="12">
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Annuler" Width="90" Margin="0,0,8,0" IsCancel="True"/>
+            <Button Content="OK" Width="90" IsDefault="True" Click="OnOk"/>
         </StackPanel>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Enregistrer" Margin="0,0,8,0" Width="100" IsDefault="True" Click="OnSave"/>
-            <Button Content="Fermer" Width="100" IsCancel="True"/>
+        <StackPanel>
+            <TextBlock Text="Monitoring" FontWeight="Bold" Margin="0,0,0,6"/>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBlock Text="Intervalle (ms):" Width="140" VerticalAlignment="Center"/>
+                <TextBox Width="120" Text="{Binding Settings.MonitoringIntervalMs}"/>
+            </StackPanel>
+
+            <TextBlock Text="Chat" FontWeight="Bold" Margin="0,8,0,6"/>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBlock Text="Durée msg (ms):" Width="140" VerticalAlignment="Center"/>
+                <TextBox Width="120" Text="{Binding Settings.DefaultMessageTtlMs}"/>
+            </StackPanel>
+
+            <TextBlock Text="Avatar" FontWeight="Bold" Margin="0,8,0,6"/>
+            <CheckBox Content="Battement léger (EnableBeatPulse)" IsChecked="{Binding Settings.EnableBeatPulse}"/>
+
+            <TextBlock Text="Compagnon" FontWeight="Bold" Margin="0,8,0,6"/>
+            <CheckBox Content="Bavard (CompanionTalkative)" IsChecked="{Binding Settings.CompanionTalkative}"/>
         </StackPanel>
-    </Grid>
+    </DockPanel>
 </Window>


### PR DESCRIPTION
- SettingsWindow: add checkboxes for EnableBeatPulse and CompanionTalkative.
- Binds directly to Settings on SettingsViewModel.
- Lets users switch beat pulse and companion chattiness without editing JSON.

Pairs with PR #101 and mood skins.