### PR TITLE
feat(scripts): Rambo repair + Network reset (PowerShell)

### DIFF
--- a/src/Virgil.App/scripts/network_reset.ps1
+++ b/src/Virgil.App/scripts/network_reset.ps1
@@ -1,0 +1,29 @@
+# Network Reset: flush DNS, reset Winsock, reset IP interfaces, renew DHCP
+# Requires: Admin
+$ErrorActionPreference = 'Stop'
+function Write-Log([string]$msg){ $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $msg" }
+
+try{
+  Write-Log 'Flushing DNS cache'
+  ipconfig /flushdns | Out-Null
+
+  Write-Log 'Resetting Winsock'
+  netsh winsock reset | Out-Null
+
+  Write-Log 'Resetting IP stack (IPv4/IPv6)'
+  netsh int ip reset | Out-Null
+  netsh int ipv6 reset | Out-Null
+
+  Write-Log 'Releasing DHCP leases'
+  ipconfig /release | Out-Null
+  Start-Sleep -Seconds 1
+  Write-Log 'Renewing DHCP leases'
+  ipconfig /renew | Out-Null
+
+  Write-Log 'Done (a reboot may be required for full effect)'
+  exit 0
+}
+catch{
+  Write-Log ("ERROR: $($_.Exception.Message)")
+  exit 1
+}

--- a/src/Virgil.App/scripts/rambo_repair.ps1
+++ b/src/Virgil.App/scripts/rambo_repair.ps1
@@ -1,0 +1,44 @@
+# Rambo Repair: restart Explorer and rebuild icon/thumbnail cache
+# Requires: Admin for some operations. Run elevated for best results.
+param([switch]$Force)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Log([string]$msg){
+  $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss';
+  Write-Output "[$ts] $msg"
+}
+
+try{
+  Write-Log 'Stopping Explorer.exe'
+  Get-Process explorer -ErrorAction SilentlyContinue | Stop-Process -Force
+
+  $local = $env:LOCALAPPDATA
+  $iconDir = Join-Path $local 'Microsoft\Windows\Explorer'
+  $thumbPattern = 'thumbcache_*'
+  $iconPattern = 'iconcache*'
+
+  Write-Log "Clearing thumbnail cache in $iconDir"
+  Get-ChildItem -Path $iconDir -Filter $thumbPattern -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+
+  Write-Log "Clearing icon cache in $iconDir"
+  Get-ChildItem -Path $iconDir -Filter $iconPattern -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+
+  if($Force){
+    # Optional deeper clean: shell icon cache in user profile (safe)
+    $userProfile = $env:USERPROFILE
+    $db = Join-Path $userProfile 'AppData\Local\IconCache.db'
+    if(Test-Path $db){ Write-Log 'Removing IconCache.db (legacy)'; Remove-Item $db -Force -ErrorAction SilentlyContinue }
+  }
+
+  Start-Sleep -Milliseconds 500
+  Write-Log 'Restarting Explorer.exe'
+  Start-Process explorer.exe
+
+  Write-Log 'Done'
+  exit 0
+}
+catch{
+  Write-Log ("ERROR: $($_.Exception.Message)")
+  exit 1
+}


### PR DESCRIPTION
Adds two system action scripts:

- rambo_repair.ps1
  * Stops Explorer.exe, clears icon/thumbnail cache (user), optional legacy IconCache.db removal with -Force, restarts Explorer.
  * Safe defaults, logs steps, exits 0/1 appropriately.

- network_reset.ps1
  * Flushes DNS, resets Winsock, resets IP stack (IPv4/IPv6), releases/renews DHCP.
  * Requires admin; logs steps, exits 0/1.

Both scripts live under src/Virgil.App/scripts/. They integrate with existing ActionsService script runner (no code changes required).