### PR TITLE
feat(scripts): full system scripts pack (maintenance, cleanup, browsers, updates, defender, store, disks, eventlogs)

### DIFF
--- a/src/Virgil.App/scripts/clean_browsers.ps1
+++ b/src/Virgil.App/scripts/clean_browsers.ps1
@@ -1,0 +1,16 @@
+# Nettoyage navigateurs (caches). Ne touche pas aux profils/sessions.
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  $local=$env:LOCALAPPDATA; $roam=$env:APPDATA
+  # Edge (Chromium)
+  $edge=Join-Path $local 'Microsoft/Edge/User Data/Default/Cache'; if(Test-Path $edge){ Log 'Edge cache'; Get-ChildItem $edge -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue }
+  # Chrome
+  $chrome=Join-Path $local 'Google/Chrome/User Data/Default/Cache'; if(Test-Path $chrome){ Log 'Chrome cache'; Get-ChildItem $chrome -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue }
+  # Firefox
+  $ffProf=Join-Path $roam 'Mozilla/Firefox/Profiles'; if(Test-Path $ffProf){
+    Get-ChildItem $ffProf -Directory | ForEach-Object { $cache=Join-Path $_.FullName 'cache2'; if(Test-Path $cache){ Log "Firefox cache: $($_.Name)"; Get-ChildItem $cache -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue } }
+  }
+  Log 'OK'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/cleanup_smart.ps1
+++ b/src/Virgil.App/scripts/cleanup_smart.ps1
@@ -1,0 +1,15 @@
+# Nettoyage intelligent: Temp, Prefetch, Recycle Bin (safe)
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  Log 'Purge Temp utilisateur'
+  $u=$env:TEMP; if(Test-Path $u){ Get-ChildItem $u -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue }
+  Log 'Purge Temp Windows'
+  $w=Join-Path $env:WINDIR 'Temp'; if(Test-Path $w){ Get-ChildItem $w -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue }
+  Log 'Nettoyage Prefetch (non critique)'
+  $p=Join-Path $env:WINDIR 'Prefetch'; if(Test-Path $p){ Get-ChildItem $p -Force -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue }
+  Log 'Vider Corbeille'
+  try{ Clear-RecycleBin -Force -ErrorAction SilentlyContinue }catch{}
+  Log 'OK'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/clear_eventlogs.ps1
+++ b/src/Virgil.App/scripts/clear_eventlogs.ps1
@@ -1,0 +1,13 @@
+# Purge journaux Windows (attention). Utiliser -Force pour bypass confirm.
+param([switch]$Force)
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  $logs = & wevtutil el
+  foreach($name in $logs){
+    if($Force){ Log "Clear $name"; & wevtutil cl $name }
+    else{ Write-Output "Would clear: $name (use -Force)" }
+  }
+  Log 'Terminé'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/defender_update_scan.ps1
+++ b/src/Virgil.App/scripts/defender_update_scan.ps1
@@ -1,6 +1,11 @@
-# Windows Defender update + quick scan
-$mp = "$Env:ProgramFiles" + '\Windows Defender\MpCmdRun.exe'
-if (Test-Path $mp) {
-  & $mp -SignatureUpdate
-  & $mp -Scan -ScanType 1
-} else { Write-Warning 'MpCmdRun not found' }
+# Defender: Update signatures + Quick scan
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  Log 'Update-MpSignature'
+  Update-MpSignature | Out-Null
+  Log 'Start-MpScan QuickScan'
+  Start-MpScan -ScanType QuickScan | Out-Null
+  Log 'OK'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/maintenance_complete.ps1
+++ b/src/Virgil.App/scripts/maintenance_complete.ps1
@@ -1,0 +1,15 @@
+# Maintenance complète: DISM, SFC, purge Temp, résumé
+# Requires: Admin
+$ErrorActionPreference = 'Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  Log 'DISM /Online /Cleanup-Image /RestoreHealth'
+  DISM /Online /Cleanup-Image /RestoreHealth | Out-Null
+  Log 'SFC /scannow'
+  sfc /scannow | Out-Null
+  Log 'Purge Temp (user + Windows Temp)'
+  $u=$env:TEMP; if(Test-Path $u){ Get-ChildItem $u -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue }
+  $w=Join-Path $env:WINDIR 'Temp'; if(Test-Path $w){ Get-ChildItem $w -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue }
+  Log 'Fini. Un redémarrage peut être recommandé.'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/optimize_disks.ps1
+++ b/src/Virgil.App/scripts/optimize_disks.ps1
@@ -1,0 +1,21 @@
+# Optimisation disques: TRIM SSD, defrag HDD
+# Requires: Admin
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  $drives = Get-Volume | Where-Object { $_.DriveLetter -ne $null }
+  foreach($d in $drives){
+    $dl = $d.DriveLetter + ':'
+    if($d.DriveType -eq 'Fixed'){
+      try{
+        $media = (Get-PhysicalDisk | Where FriendlyName -Like '*').MediaType
+      }catch{}
+      Log "Optimize-Volume $dl (TRIM)"
+      Optimize-Volume -DriveLetter $d.DriveLetter -ReTrim -ErrorAction SilentlyContinue | Out-Null
+      Log "Defrag $dl (si applicable)"
+      defrag $dl /O | Out-Null
+    }
+  }
+  Log 'OK'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/store_repair.ps1
+++ b/src/Virgil.App/scripts/store_repair.ps1
@@ -1,0 +1,11 @@
+# Microsoft Store reset + re-register (si nécessaire)
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  Log 'wsreset.exe'
+  Start-Process wsreset.exe -Wait
+  Log 'Re-enregistrement Microsoft Store (AllUsers)'
+  Get-AppxPackage -AllUsers Microsoft.WindowsStore | Foreach { Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppxManifest.xml" }
+  Log 'OK'
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }

--- a/src/Virgil.App/scripts/update_all.ps1
+++ b/src/Virgil.App/scripts/update_all.ps1
@@ -1,2 +1,10 @@
-# Updating all via winget (if available)
-try { winget upgrade --all --silent } catch { Write-Warning 'winget not available' }
+# Mise à jour applications via winget + note Store
+$ErrorActionPreference='Stop'
+function Log([string]$m){ $ts=Get-Date -Format 'yyyy-MM-dd HH:mm:ss'; Write-Output "[$ts] $m" }
+try{
+  Log 'Winget upgrade --all'
+  winget source update | Out-Null
+  winget upgrade --all --accept-source-agreements --accept-package-agreements --silent | Write-Output
+  Log 'Note: mises à jour Microsoft Store non garanties par ce script (voir store_repair.ps1 si souci)'.
+  exit 0
+}catch{ Log ("ERROR: $($_.Exception.Message)"); exit 1 }


### PR DESCRIPTION
This adds the first full set of PowerShell scripts used by ActionsService:

- maintenance_complete.ps1 — DISM + SFC + Temp purge
- cleanup_smart.ps1 — Temp + Prefetch + Recycle Bin (safe)
- clean_browsers.ps1 — cache cleanup for Edge/Chrome/Firefox (no profile wipe)
- update_all.ps1 — winget upgrade --all (notes Store separately)
- defender_update_scan.ps1 — Update signatures + Quick scan
- store_repair.ps1 — wsreset + re-register Store
- optimize_disks.ps1 — TRIM/defrag as applicable
- clear_eventlogs.ps1 — purge logs, dry-run unless -Force

All scripts log steps and return exit codes (0 ok / 1 error). They live in src/Virgil.App/scripts/ and can be invoked by existing UI buttons.