### PR TITLE
Refine SystemMetricsModel property setter

### DIFF
--- a/src/Virgil.Core/Models/SystemMetricsModel.cs
+++ b/src/Virgil.Core/Models/SystemMetricsModel.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Virgil.Core.Models
+{
+    /// <summary>
+    /// Represents observable system metrics for UI binding scenarios.
+    /// </summary>
+    public class SystemMetricsModel : INotifyPropertyChanged
+    {
+        private float _cpuUsage;
+        private float _ramUsage;
+        private float _cpuTemp;
+        private float _gpuTemp;
+        private float _diskUsage;
+
+        public float CpuUsage
+        {
+            get => _cpuUsage;
+            set => SetProperty(ref _cpuUsage, value);
+        }
+
+        public float RamUsage
+        {
+            get => _ramUsage;
+            set => SetProperty(ref _ramUsage, value);
+        }
+
+        public float CpuTemp
+        {
+            get => _cpuTemp;
+            set => SetProperty(ref _cpuTemp, value);
+        }
+
+        public float GpuTemp
+        {
+            get => _gpuTemp;
+            set => SetProperty(ref _gpuTemp, value);
+        }
+
+        public float DiskUsage
+        {
+            get => _diskUsage;
+            set => SetProperty(ref _diskUsage, value);
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private bool SetProperty<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor SystemMetricsModel setters to use a shared SetProperty helper
- keep change guards while reducing duplication and adding CallerMemberName support

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8f1e0b9c8332b97cb222ba9c87c8)