### PR TITLE
Restore monitoring compatibility

### DIFF
--- a/src/Virgil.App/MainWindow.Monitoring.cs
+++ b/src/Virgil.App/MainWindow.Monitoring.cs
@@ -1,26 +1,19 @@
 using System;
-using System.Windows.Threading;
+using System.Threading;
 
 namespace Virgil.App
 {
     public partial class MainWindow
     {
-        private readonly DispatcherTimer _monitorTimer = new();
-
         private void StartMonitoring()
         {
-            _monitorTimer.Interval = TimeSpan.FromSeconds(2);
-            _monitorTimer.Tick += (s, e) =>
-            {
-                // TODO : lecture CPU/GPU/RAM/Températures
-                // Actualise les jauges + émotions dans le ViewModel
-            };
-            _monitorTimer.Start();
+            // Démarre le service de monitoring bas niveau (compteurs Windows + LHM).
+            _ = _systemMonitorService.StartAsync(CancellationToken.None);
         }
 
         private void StopMonitoring()
         {
-            _monitorTimer.Stop();
+            _ = _systemMonitorService.StopAsync(CancellationToken.None);
         }
     }
 }

--- a/src/Virgil.App/MainWindow.xaml.cs
+++ b/src/Virgil.App/MainWindow.xaml.cs
@@ -1,8 +1,9 @@
 // AUTO-PATCH: pass ChatService into MainViewModel ctor
+using System.Threading;
 using System.Windows;
 using Virgil.App.Chat;
-using Virgil.App.ViewModels;
 using Virgil.App.Services;
+using Virgil.App.ViewModels;
 using Virgil.Domain;
 using Virgil.Services.Narration;
 
@@ -10,23 +11,25 @@ namespace Virgil.App
 {
     public partial class MainWindow : Window
     {
+        private readonly ISystemMonitorService _systemMonitorService;
+        private readonly MonitoringViewModel _monitoringVm;
+
         public MainWindow()
         {
             InitializeComponent();
 
             var chat = new ChatService();
+            var settingsService = new SettingsService();
+            var networkInsightService = new NetworkInsightService();
 
-            var monitoringVm = new MonitoringViewModel(
-                new MonitoringService(),
-                new SettingsService(),
-                new NetworkInsightService()
-            );
+            _systemMonitorService = new SystemMonitorService();
+            _monitoringVm = new MonitoringViewModel(_systemMonitorService, settingsService, networkInsightService);
 
             // Services d'actions
             var systemActionsService = new SystemActionsService();
             var networkActionsService = new NetworkActionsService();
             var performanceActionsService = new PerformanceActionsService();
-            var specialActionsService = new SpecialActionsService(chat, new SettingsService(), new MonitoringService());
+            var specialActionsService = new SpecialActionsService(chat, settingsService, new MonitoringService());
             var phraseService = new VirgilPhraseService();
             var narrationService = new VirgilNarrationService(chat, phraseService);
 
@@ -38,7 +41,10 @@ namespace Virgil.App
                 specialActionsService
             );
 
-            DataContext = new MainViewModel(chat, monitoringVm, actionsVm);
+            DataContext = new MainViewModel(chat, _monitoringVm, actionsVm);
+
+            Loaded += (_, _) => StartMonitoring();
+            Closed += (_, _) => StopMonitoring();
         }
     }
 }


### PR DESCRIPTION
## Summary
- reintroduce monitoring settings/network dependencies while wiring snapshot updates through the new system monitor service
- support both legacy MonitoringService events and SystemMonitorService snapshots in MonitoringViewModel with UI-thread marshalling
- share settings/network services in MainWindow and keep monitoring service lifecycle hooks

## Testing
- not run (dotnet CLI unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea44e104483329565467dde8cfa16)