### PR TITLE
Remove deprecated include-prerelease option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,5 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-          include-prerelease: true
       - run: dotnet restore
       - run: dotnet build -c Release --no-restore

--- a/.github/workflows/dotnet-build-and-artifact.yml
+++ b/.github/workflows/dotnet-build-and-artifact.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-          include-prerelease: true
 
       - name: Restore
         run: dotnet restore


### PR DESCRIPTION
## Summary
- remove the deprecated `include-prerelease` input from setup-dotnet steps in build workflows

## Testing
- not run (CI workflows only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea7c8f3e88332b305dfd9fe5a61be)