### PR TITLE
Handle monitoring initialization failures

### DIFF
--- a/src/Virgil.App/MainWindow.Monitoring.cs
+++ b/src/Virgil.App/MainWindow.Monitoring.cs
@@ -8,12 +8,26 @@ namespace Virgil.App
         private void StartMonitoring()
         {
             // Démarre le service de monitoring bas niveau (compteurs Windows + LHM).
-            _ = _systemMonitorService.StartAsync(CancellationToken.None);
+            if (_systemMonitorService is not null)
+            {
+                _ = _systemMonitorService.StartAsync(CancellationToken.None);
+            }
+            else
+            {
+                _legacyMonitoringService?.Start();
+            }
         }
 
         private void StopMonitoring()
         {
-            _ = _systemMonitorService.StopAsync(CancellationToken.None);
+            if (_systemMonitorService is not null)
+            {
+                _ = _systemMonitorService.StopAsync(CancellationToken.None);
+            }
+            else
+            {
+                _legacyMonitoringService?.Stop();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a fallback to the legacy monitoring service when the new system monitor fails to initialize
- guard monitoring start/stop routines to use the available implementation and avoid startup crashes

## Testing
- not run (environment lacks dotnet SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea86865648332aadbb7c6b1d68eff)