### PR TITLE
Add browsers pack to capabilities spec

### DIFF
--- a/docs/spec/capabilities/ALIGNEMENT_MEMO.md
+++ b/docs/spec/capabilities/ALIGNEMENT_MEMO.md
@@ -36,7 +36,7 @@ Le projet Virgil est **100% conforme** au mémo de reprise et même **en avance*
 - IA locale 100% textuelle, propose seulement
 
 **État actuel** : ✅ **CONFORME**
-- `capabilities.v3.json` : 67 capabilities avec structure complète
+- `capabilities.v3.json` : 77 capabilities avec structure complète
 - Tous les champs requis présents (ID, niveau, risque, dry-run, rollback)
 - Schémas JSON pour l'IA (`ai_request.schema.json`, `ai_response.schema.json`)
 - Aucun code d'exécution libre ou de commandes générées
@@ -147,7 +147,7 @@ docs/spec/capabilities/catalog/
 | Fichier | Capabilities | Domaines | Statut |
 |---------|--------------|----------|--------|
 | audit.json | 3 | AUDIT | ✅ |
-| browsers.json | 0 | (vide) | ⚠️ stub |
+| browsers.json | 10 | CLEANING | ✅ |
 | cleaning.json | 13 | CLEANING, DISK | ✅ |
 | network.json | 2 | NETWORK | ✅ |
 | performance.json | 6 | PERFORMANCE, MONITORING | ✅ |
@@ -158,7 +158,7 @@ docs/spec/capabilities/catalog/
 | uninstall.json | 2 | UNINSTALL, APPX | ✅ |
 | updates.json | 5 | UPDATES | ✅ |
 
-**Total** : 67 capabilities distribuées (100% de l'existant)
+**Total** : 77 capabilities distribuées (100% de l'existant)
 
 ---
 
@@ -191,7 +191,7 @@ Le projet va **au-delà** du mémo sur ces points :
 
 ### 1. Distribution immédiate des capabilities
 **Mémo** : Suggère de créer la structure catalog/  
-**Virgil** : Structure créée ET 67 capabilities déjà distribuées
+**Virgil** : Structure créée ET 77 capabilities déjà distribuées
 
 **Justification** : Gain de temps, structure validée, distribution réversible si besoin
 
@@ -216,10 +216,10 @@ Le projet va **au-delà** du mémo sur ces points :
 
 ## ⚠️ POINTS D'ATTENTION
 
-### 1. browsers.json vide
-**État** : Fichier stub sans capabilities  
-**Raison** : Aucune capability BROWSERS dans capabilities.v3.json  
-**Action** : Normal, en attente de l'enrichissement du catalogue
+### 1. browsers.json complété
+**État** : 10 capabilities CLEAN_BROWSER_* ajoutées dans catalog/ et capabilities.v3.json
+**Raison** : Priorité haute traitée pour couvrir les actions navigateurs essentielles
+**Action** : Surveiller les besoins futurs (IndexedDB avancé, nouvelles plateformes) mais le pack est opérationnel
 
 ### 2. Packs multi-domaines
 **État** : Certains packs contiennent plusieurs domaines (ex: tools.json)  
@@ -235,7 +235,7 @@ Le projet va **au-delà** du mémo sur ces points :
 - [x] Vision produit alignée
 - [x] Architecture V3 respectée
 - [x] Structure docs/spec/capabilities/ complète
-- [x] capabilities.v3.json avec 67 capabilities
+- [x] capabilities.v3.json avec 77 capabilities
 - [x] Schémas JSON (ai_request, ai_response)
 - [x] README.md avec règles fondamentales
 - [x] COVERAGE.md créé et structuré
@@ -261,20 +261,16 @@ Selon le mémo et l'état actuel, la **prochaine action** est :
 
 ### Option A : Enrichir le catalogue (Étape 2 suite)
 
-**Commencer par** : Pack browsers.json (priorité HAUTE selon COVERAGE.md)
+**Commencer par** : Packs cleaning, security, performance selon priorités restantes
 
-**Capabilities à ajouter** :
-1. BROWSERS_COOKIE_CLEAN_SELECTIVE
-2. BROWSERS_HISTORY_CLEAN
-3. BROWSERS_STORAGE_CLEAN (IndexedDB/LocalStorage)
-4. BROWSERS_SESSIONS_MANAGE
-5. BROWSERS_EXTENSIONS_ORPHAN_CLEAN
-
-**Ensuite** : Packs cleaning, security, performance selon priorités
+**Exemples de next steps** :
+- CLEAN_WINDOWS_OLD / CLEAN_MIGRATION_LEFTOVERS
+- DEFENDER_SCAN_FULL / SECURITY_PERMISSIONS_AUDIT
+- PERF_SET_PROCESS_PRIORITY / PERF_SET_CPU_AFFINITY
 
 ### Option B : Passer au code C# (Étape 3)
 
-**Si** le catalogue actuel (67 capabilities) est jugé suffisant pour démarrer.
+**Si** le catalogue actuel (77 capabilities) est jugé suffisant pour démarrer.
 
 **Créer** : CapabilityLoader.cs dans Virgil.Core pour :
 - Charger capabilities.v3.json
@@ -315,7 +311,7 @@ Je travaille sur Virgil (https://github.com/bassetthomas-design/Virgil).
 - Étape 1 (Coverage) : ✅ TERMINÉE
 - Étape 2 (Structure catalog) : ✅ TERMINÉE  
 - Étape 2 (Enrichissement) : 🔄 EN COURS
-- 67 capabilities existantes distribuées dans 11 packs
+- 77 capabilities existantes distribuées dans 11 packs
 - COVERAGE.md identifie ~60 capabilities manquantes
 
 Le projet suit le mémo de reprise V3 avec :
@@ -330,7 +326,7 @@ Consulter :
 - docs/spec/capabilities/ALIGNEMENT_MEMO.md (validation mémo)
 
 Objectif : [CHOISIR]
-A) Enrichir le catalogue (browsers.json en priorité)
+A) Enrichir le catalogue (cleaning/security/performance en priorité)
 B) Passer au code C# (CapabilityLoader)
 ```
 

--- a/docs/spec/capabilities/REPRISE_STATUS.md
+++ b/docs/spec/capabilities/REPRISE_STATUS.md
@@ -9,7 +9,7 @@
 
 Le projet Virgil a franchi les **Étapes 1 et 2** du plan de reprise :
 - ✅ **Étape 1 (Coverage)** : COVERAGE.md créé et structuré
-- ✅ **Étape 2 (Structure catalog)** : 11 packs créés et 67 capabilities distribuées
+- ✅ **Étape 2 (Structure catalog)** : 11 packs créés et 77 capabilities distribuées
 - 🔄 **Étape 2 (Contenu)** : Catalogue à enrichir avec les capabilities manquantes
 - ⏳ **Étape 3+** : Code C# en attente
 
@@ -22,14 +22,14 @@ Le projet Virgil a franchi les **Étapes 1 et 2** du plan de reprise :
 ```
 docs/spec/capabilities/
 ├── README.md                    ✅ Règles fondamentales
-├── capabilities.v3.json         ✅ 67 capabilities existantes
+├── capabilities.v3.json         ✅ 77 capabilities existantes
 ├── ai_request.schema.json       ✅ Contrat requête IA
 ├── ai_response.schema.json      ✅ Contrat réponse IA
 ├── COVERAGE.md                  ✅ Mapping cahier des charges → capabilities
 ├── REPRISE_STATUS.md            ✅ Ce fichier
 └── catalog/                     ✅ Packs de capabilities
     ├── audit.json               ✅ 3 capabilities (AUDIT)
-    ├── browsers.json            ⚠️  0 capabilities (stub, en attente)
+    ├── browsers.json            ✅ 10 capabilities (CLEANING)
     ├── cleaning.json            ✅ 13 capabilities (CLEANING, DISK)
     ├── network.json             ✅ 2 capabilities (NETWORK)
     ├── performance.json         ✅ 6 capabilities (PERFORMANCE, MONITORING)
@@ -41,7 +41,7 @@ docs/spec/capabilities/
     └── updates.json             ✅ 5 capabilities (UPDATES)
 ```
 
-**Total distribué** : 67 capabilities (100% des capabilities existantes)
+**Total distribué** : 77 capabilities (catalogue enrichi avec le pack navigateurs)
 
 ---
 
@@ -74,7 +74,7 @@ docs/spec/capabilities/
 
 **Réalisations** :
 - 11 fichiers de packs créés dans `catalog/`
-- 67 capabilities distribuées par domaine
+- 77 capabilities distribuées par domaine
 - Structure JSON validée pour tous les fichiers
 - Descriptions mises à jour pour clarifier les packs multi-domaines
 
@@ -83,7 +83,7 @@ docs/spec/capabilities/
 | Pack | Domaines | Capabilities | Statut |
 |------|----------|--------------|--------|
 | `audit.json` | AUDIT | 3 | ✅ |
-| `browsers.json` | (à définir) | 0 | ⚠️ stub |
+| `browsers.json` | CLEANING | 10 | ✅ |
 | `cleaning.json` | CLEANING, DISK | 13 | ✅ |
 | `network.json` | NETWORK | 2 | ✅ |
 | `performance.json` | PERFORMANCE, MONITORING | 6 | ✅ |
@@ -104,12 +104,8 @@ docs/spec/capabilities/
 
 #### Priorité HAUTE
 1. **Pack browsers** (browsers.json)
-   - BROWSERS_CACHE_GLOBAL → existe déjà (CLEAN_BROWSER_CACHE_ALL)
-   - BROWSERS_COOKIE_CLEAN_SELECTIVE ❌
-   - BROWSERS_HISTORY_CLEAN ❌
-   - BROWSERS_STORAGE_CLEAN (IndexedDB/LocalStorage) ❌
-   - BROWSERS_SESSIONS_MANAGE ❌
-   - BROWSERS_EXTENSIONS_ORPHAN_CLEAN ❌
+   - ✅ 10 capabilities ajoutées (cookies, historique, stockage, sessions, extensions)
+   - Continuer l'enrichissement si de nouvelles actions navigateur sont identifiées
 
 2. **Pack cleaning** (cleaning.json)
    - CLEAN_WINDOWS_OLD ❌
@@ -232,12 +228,12 @@ Je travaille sur Virgil.
 Repo : https://github.com/bassetthomas-design/Virgil
 
 État actuel :
-- 67 capabilities existantes distribuées dans 11 packs
-- COVERAGE.md identifie ~60 capabilities manquantes
+- 77 capabilities existantes distribuées dans 11 packs
+- COVERAGE.md identifie encore des capabilities manquantes
 - Structure catalog/ prête
 
 Objectif : ajouter les capabilities manquantes dans les packs appropriés.
-Commencer par le pack browsers.json (priorité haute).
+Commencer par les priorités hautes restantes (cleaning/security/performance).
 ```
 
 ### Si vous voulez passer au code C# :
@@ -248,7 +244,7 @@ Repo : https://github.com/bassetthomas-design/Virgil
 
 État actuel :
 - Catalogue V3 complet (docs/spec/capabilities/)
-- 67 capabilities existantes + structure pour enrichissement
+- 77 capabilities existantes + structure pour enrichissement
 - Aucun code C# d'intégration encore
 
 Objectif : créer le CapabilityLoader (Étape 3) pour charger
@@ -270,10 +266,10 @@ Avant de passer à l'étape suivante, vérifier :
 - [x] Dossier catalog/ existe
 - [x] 11 packs JSON créés
 - [x] Tous les JSON sont valides
-- [x] 67 capabilities distribuées (100%)
+- [x] 77 capabilities distribuées (100%)
 
 ### Étape 2 (Contenu) 🔄
-- [ ] Pack browsers complété
+- [x] Pack browsers complété
 - [ ] Capabilities de nettoyage avancé ajoutées
 - [ ] Capabilities de sécurité complètes
 - [ ] Capabilities de performance ajoutées
@@ -312,5 +308,5 @@ Avant de passer à l'étape suivante, vérifier :
 
 ---
 
-**Dernière mise à jour** : 2025-12-19  
-**Prochaine action recommandée** : Enrichir le pack browsers.json avec les capabilities navigateur manquantes
+**Dernière mise à jour** : 2025-12-19
+**Prochaine action recommandée** : Poursuivre l'enrichissement des packs cleaning/security/performance après l'ajout du pack navigateurs

--- a/docs/spec/capabilities/capabilities.v3.json
+++ b/docs/spec/capabilities/capabilities.v3.json
@@ -240,6 +240,498 @@
       "tags": []
     },
     {
+      "id": "CLEAN_BROWSER_COOKIES_SELECTIVE",
+      "title": "Nettoyer cookies navigateurs (sélectif)",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_COOKIES_BACKUP"
+      ],
+      "risk": "MEDIUM",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "excludeDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "olderThanDays": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "description": "Nettoie sélectivement les cookies des navigateurs en préservant les domaines spécifiés et en respectant les critères d'âge",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_HISTORY",
+      "title": "Nettoyer historique navigateurs",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_HISTORY_BACKUP"
+      ],
+      "risk": "LOW",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "olderThanDays": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "keepLastN": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "description": "Nettoie l'historique de navigation avec options pour conserver les N dernières entrées ou supprimer uniquement les anciennes",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_STORAGE_LOCAL",
+      "title": "Nettoyer LocalStorage navigateurs",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_STORAGE_BACKUP"
+      ],
+      "risk": "MEDIUM",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "excludeDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "description": "Nettoie le LocalStorage des navigateurs avec possibilité d'exclure des domaines spécifiques",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_STORAGE_SESSION",
+      "title": "Nettoyer SessionStorage navigateurs",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [],
+      "risk": "LOW",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "description": "Nettoie le SessionStorage des navigateurs (données temporaires de session)",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_EXTENSIONS_LIST",
+      "title": "Lister et nettoyer extensions navigateurs",
+      "level": "ADVANCED",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_EXTENSIONS_BACKUP"
+      ],
+      "risk": "MEDIUM",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "removeOrphaned": {
+            "type": "boolean"
+          },
+          "removeDisabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "description": "Liste les extensions installées et permet de nettoyer les extensions orphelines ou désactivées",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_CACHE_PER_PROFILE",
+      "title": "Nettoyer cache navigateurs par profil",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [],
+      "risk": "LOW",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "includeImageCache": {
+            "type": "boolean"
+          },
+          "includeMediaCache": {
+            "type": "boolean"
+          }
+        }
+      },
+      "description": "Nettoie le cache des navigateurs de manière ciblée par profil utilisateur avec options pour types de cache",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_SESSIONS_PRESERVE_LOGGED_IN",
+      "title": "Nettoyer sessions navigateurs en préservant connexions",
+      "level": "ADVANCED",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_SESSION_BACKUP"
+      ],
+      "risk": "MEDIUM",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "preserveLoggedIn": {
+            "type": "boolean"
+          },
+          "preserveDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "description": "Nettoie les sessions de navigation tout en préservant les authentifications et domaines spécifiés",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_PROFILES_INACTIVE",
+      "title": "Nettoyer profils navigateurs inactifs",
+      "level": "ADVANCED",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_PROFILE_BACKUP"
+      ],
+      "risk": "HIGH",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "inactiveDays": {
+            "type": "integer",
+            "minimum": 30
+          },
+          "excludeProfiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "description": "Détecte et nettoie les profils de navigateurs non utilisés depuis un nombre de jours spécifié",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_DOWNLOADS_LIST",
+      "title": "Nettoyer liste téléchargements navigateurs",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_DOWNLOADS_BACKUP"
+      ],
+      "risk": "LOW",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "olderThanDays": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "keepLastN": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "description": "Nettoie l'historique des téléchargements dans les navigateurs (ne supprime pas les fichiers téléchargés)",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
+      "id": "CLEAN_BROWSER_FORM_AUTOFILL",
+      "title": "Nettoyer données auto-remplissage navigateurs",
+      "level": "ADVANCED",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [
+        "BROWSER_AUTOFILL_BACKUP"
+      ],
+      "risk": "MEDIUM",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "browsers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Chrome",
+                "Firefox",
+                "Edge",
+                "Brave",
+                "Opera"
+              ]
+            }
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "includeAddresses": {
+            "type": "boolean"
+          },
+          "includePaymentMethods": {
+            "type": "boolean"
+          },
+          "excludePasswords": {
+            "type": "boolean"
+          }
+        }
+      },
+      "description": "Nettoie les données d'auto-remplissage des formulaires (adresses, moyens de paiement) tout en préservant optionnellement les mots de passe",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
       "id": "CLEAN_APP_CACHE",
       "title": "Nettoyer cache applicatif (par profile d'app)",
       "level": "CORE",


### PR DESCRIPTION
## Summary
- add the 10 browser capabilities to `capabilities.v3.json` so the aggregate matches the catalog
- refresh status documentation to reflect the browsers pack completion and updated totals

## Testing
- python - <<'PY'
import json
from pathlib import Path
catalog_dir=Path('docs/spec/capabilities/catalog')
all_caps=[]
for path in catalog_dir.glob('*.json'):
    data=json.load(open(path))
    all_caps += [c['id'] for c in data.get('capabilities',[])]
cap_file=json.load(open('docs/spec/capabilities/capabilities.v3.json'))
listed=[c['id'] for c in cap_file.get('capabilities',[])]
missing=[c for c in all_caps if c not in listed]
print('missing', len(missing))
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb508d4748332b6cffcdde8eb2c84)