### PR TITLE
Add cache-all capability to browsers catalog

### DIFF
--- a/docs/spec/capabilities/catalog/browsers.json
+++ b/docs/spec/capabilities/catalog/browsers.json
@@ -7,6 +7,40 @@
   "description": "Pack de capabilities pour navigateurs - nettoyage avancé et gestion des données de navigation",
   "capabilities": [
     {
+      "id": "CLEAN_BROWSER_CACHE_ALL",
+      "title": "Nettoyer cache navigateurs (tous détectés)",
+      "level": "CORE",
+      "domain": "CLEANING",
+      "requiresAdmin": false,
+      "supportsDryRun": true,
+      "rollback": [],
+      "risk": "LOW",
+      "paramsSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "CACHE_ONLY",
+              "SMART",
+              "DEEP",
+              "NUCLEAR"
+            ]
+          },
+          "keepPasswords": {
+            "type": "boolean"
+          }
+        }
+      },
+      "description": "Nettoie le cache de tous les navigateurs détectés avec plusieurs niveaux d'intensité",
+      "tags": [
+        "browsers",
+        "cleaning",
+        "dry-run"
+      ]
+    },
+    {
       "id": "CLEAN_BROWSER_COOKIES_SELECTIVE",
       "title": "Nettoyer cookies navigateurs (sélectif)",
       "level": "CORE",

--- a/tests/Virgil.Tests/CatalogBrowserJsonSchemaTests.cs
+++ b/tests/Virgil.Tests/CatalogBrowserJsonSchemaTests.cs
@@ -371,6 +371,7 @@ public class CatalogBrowserJsonSchemaTests
         
         var expectedIds = new[]
         {
+            "CLEAN_BROWSER_CACHE_ALL",
             "CLEAN_BROWSER_COOKIES_SELECTIVE",
             "CLEAN_BROWSER_HISTORY",
             "CLEAN_BROWSER_STORAGE_LOCAL",


### PR DESCRIPTION
## Summary
- add the CLEAN_BROWSER_CACHE_ALL entry to the browsers capability catalog with parameters, risk, and tags
- extend catalog schema tests to expect the new capability id

## Testing
- dotnet test *(not run: dotnet CLI unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec166d4948332abd8c811ced17ef0)