### PR TITLE
Deduplicate browser cache capability documentation

### DIFF
--- a/docs/spec/capabilities/ALIGNEMENT_MEMO.md
+++ b/docs/spec/capabilities/ALIGNEMENT_MEMO.md
@@ -217,7 +217,7 @@ Le projet va **au-delà** du mémo sur ces points :
 ## ⚠️ POINTS D'ATTENTION
 
 ### 1. browsers.json complété
-**État** : 10 capabilities CLEAN_BROWSER_* ajoutées dans catalog/ et capabilities.v3.json
+**État** : 11 capabilities CLEAN_BROWSER_* ajoutées dans catalog/ et capabilities.v3.json (CLEAN_BROWSER_CACHE_ALL déplacée depuis cleaning.json pour éviter les doublons)
 **Raison** : Priorité haute traitée pour couvrir les actions navigateurs essentielles
 **Action** : Surveiller les besoins futurs (IndexedDB avancé, nouvelles plateformes) mais le pack est opérationnel
 

--- a/docs/spec/capabilities/COVERAGE.md
+++ b/docs/spec/capabilities/COVERAGE.md
@@ -126,9 +126,9 @@ Notes :
 ---
 
 ## Historique des modifications
+- 2025-12-26 : Ajout de CLEAN_BROWSER_CACHE_ALL dans catalog/browsers.json (déplacé depuis cleaning.json pour éviter les doublons ; le pack navigateurs compte désormais 11 capabilities)
 - 2025-12-19 : Ajout de 10 capabilities navigateurs dans catalog/browsers.json (CLEAN_BROWSER_COOKIES_SELECTIVE, CLEAN_BROWSER_HISTORY, CLEAN_BROWSER_STORAGE_LOCAL, CLEAN_BROWSER_STORAGE_SESSION, CLEAN_BROWSER_EXTENSIONS_LIST, CLEAN_BROWSER_CACHE_PER_PROFILE, CLEAN_BROWSER_SESSIONS_PRESERVE_LOGGED_IN, CLEAN_BROWSER_PROFILES_INACTIVE, CLEAN_BROWSER_DOWNLOADS_LIST, CLEAN_BROWSER_FORM_AUTOFILL)
 - 2025-12-16 : Création initiale (template)
-- 2025-12-19 : Ajout de 10 capabilities navigateurs dans catalog/browsers.json (cookies sélectifs, historique, stockage local/session, extensions, cache par profil, sessions, profils inactifs, téléchargements, auto-complétion)
 
 ---
 

--- a/docs/spec/capabilities/REPRISE_STATUS.md
+++ b/docs/spec/capabilities/REPRISE_STATUS.md
@@ -29,8 +29,8 @@ docs/spec/capabilities/
 ├── REPRISE_STATUS.md            ✅ Ce fichier
 └── catalog/                     ✅ Packs de capabilities
     ├── audit.json               ✅ 3 capabilities (AUDIT)
-    ├── browsers.json            ✅ 10 capabilities (CLEANING)
-    ├── cleaning.json            ✅ 13 capabilities (CLEANING, DISK)
+    ├── browsers.json            ✅ 11 capabilities (CLEANING)
+    ├── cleaning.json            ✅ 12 capabilities (CLEANING, DISK)
     ├── network.json             ✅ 2 capabilities (NETWORK)
     ├── performance.json         ✅ 6 capabilities (PERFORMANCE, MONITORING)
     ├── registry.json            ✅ 2 capabilities (REGISTRY)
@@ -104,7 +104,7 @@ docs/spec/capabilities/
 
 #### Priorité HAUTE
 1. **Pack browsers** (browsers.json)
-   - ✅ 10 capabilities ajoutées (cookies, historique, stockage, sessions, extensions)
+   - ✅ 11 capabilities ajoutées (cache global, cookies, historique, stockage, sessions, extensions)
    - Continuer l'enrichissement si de nouvelles actions navigateur sont identifiées
 
 2. **Pack cleaning** (cleaning.json)

--- a/docs/spec/capabilities/catalog/cleaning.json
+++ b/docs/spec/capabilities/catalog/cleaning.json
@@ -181,36 +181,6 @@
       "tags": []
     },
     {
-      "id": "CLEAN_BROWSER_CACHE_ALL",
-      "title": "Nettoyer cache navigateurs (tous détectés)",
-      "level": "CORE",
-      "domain": "CLEANING",
-      "requiresAdmin": false,
-      "supportsDryRun": true,
-      "rollback": [],
-      "risk": "LOW",
-      "paramsSchema": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": [
-              "CACHE_ONLY",
-              "SMART",
-              "DEEP",
-              "NUCLEAR"
-            ]
-          },
-          "keepPasswords": {
-            "type": "boolean"
-          }
-        }
-      },
-      "description": "Nettoyer cache navigateurs (tous détectés)",
-      "tags": []
-    },
-    {
       "id": "CLEAN_APP_CACHE",
       "title": "Nettoyer cache applicatif (par profile d'app)",
       "level": "CORE",


### PR DESCRIPTION
## Summary
- removed the duplicate CLEAN_BROWSER_CACHE_ALL entry from the cleaning pack so the capability only lives in the browsers catalog
- updated capability counts across the status and alignment docs to reflect 11 browser items and 12 cleaning items
- recorded the cache-all move in the coverage history to document the catalog change

## Testing
- dotnet test *(not run; dotnet is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec347c0a88332bd359dcebd28a8c1)