### PR TITLE
Defer mini HUD initialization until window is shown

### DIFF
--- a/src/Virgil.App/Controls/AvatarView.xaml.cs
+++ b/src/Virgil.App/Controls/AvatarView.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using Virgil.Core.Services;
 
 namespace Virgil.App.Controls;
 
@@ -56,12 +57,21 @@ public partial class AvatarView : UserControl
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
             return;
 
-        var bmp = new BitmapImage();
-        bmp.BeginInit();
-        bmp.CacheOption = BitmapCacheOption.OnLoad;
-        bmp.UriSource = new Uri(path, UriKind.Absolute);
-        bmp.EndInit();
-        bmp.Freeze();
+        BitmapImage bmp;
+        try
+        {
+            bmp = new BitmapImage();
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad;
+            bmp.UriSource = new Uri(path, UriKind.Absolute);
+            bmp.EndInit();
+            bmp.Freeze();
+        }
+        catch (Exception ex)
+        {
+            LoggingService.SafeError(ex, "Avatar image load failed for {Path}", path);
+            return;
+        }
 
         // Charge la nouvelle image sur la couche front, puis fondu croisé
         ImgFront.Source = bmp;

--- a/src/Virgil.App/Views/MainShell.xaml.cs
+++ b/src/Virgil.App/Views/MainShell.xaml.cs
@@ -167,7 +167,8 @@ namespace Virgil.App.Views
 
             if (_settingsService.Settings.ShowMiniHud)
             {
-                OnHudToggled(this, new RoutedEventArgs());
+                // Defer HUD creation until the main window is shown to avoid owner errors at startup
+                Dispatcher.BeginInvoke(new Action(() => OnHudToggled(this, new RoutedEventArgs())), DispatcherPriority.Loaded);
             }
 
         }


### PR DESCRIPTION
## Summary
- defer auto-opening the mini HUD until after the main window is shown
- avoid setting the HUD owner before the main window is visible to prevent startup crashes

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec8c4bfac8332a37f97b2adcfb0c7)