### PR TITLE
Set monitoring metric bindings to OneWay

### DIFF
--- a/src/Virgil.App/Controls/AvatarView.xaml.cs
+++ b/src/Virgil.App/Controls/AvatarView.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using Virgil.Core.Services;
 
 namespace Virgil.App.Controls;
 
@@ -56,12 +57,21 @@ public partial class AvatarView : UserControl
         if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
             return;
 
-        var bmp = new BitmapImage();
-        bmp.BeginInit();
-        bmp.CacheOption = BitmapCacheOption.OnLoad;
-        bmp.UriSource = new Uri(path, UriKind.Absolute);
-        bmp.EndInit();
-        bmp.Freeze();
+        BitmapImage bmp;
+        try
+        {
+            bmp = new BitmapImage();
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad;
+            bmp.UriSource = new Uri(path, UriKind.Absolute);
+            bmp.EndInit();
+            bmp.Freeze();
+        }
+        catch (Exception ex)
+        {
+            LoggingService.SafeError(ex, "Avatar image load failed for {Path}", path);
+            return;
+        }
 
         // Charge la nouvelle image sur la couche front, puis fondu croisé
         ImgFront.Source = bmp;

--- a/src/Virgil.App/MainWindow.xaml
+++ b/src/Virgil.App/MainWindow.xaml
@@ -36,18 +36,18 @@
             <GroupBox Header="Système" Margin="0,12,0,0" Background="{DynamicResource App.PanelBrush}">
                 <StackPanel>
                     <TextBlock Text="CPU" Foreground="{DynamicResource App.SubtleBrush}"/>
-                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.CpuUsage}"/>
+                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.CpuUsage, Mode=OneWay}"/>
                     <TextBlock Text="{Binding Monitoring.CpuTemp, StringFormat=Temp: {0}°C}"/>
 
                     <TextBlock Text="GPU" Foreground="{DynamicResource App.SubtleBrush}" Margin="0,8,0,0"/>
-                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.GpuUsage}"/>
+                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.GpuUsage, Mode=OneWay}"/>
                     <TextBlock Text="{Binding Monitoring.GpuTemp, StringFormat=Temp: {0}°C}"/>
 
                     <TextBlock Text="RAM" Foreground="{DynamicResource App.SubtleBrush}" Margin="0,8,0,0"/>
-                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.RamUsage}"/>
+                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.RamUsage, Mode=OneWay}"/>
 
                     <TextBlock Text="DISQUE" Foreground="{DynamicResource App.SubtleBrush}" Margin="0,8,0,0"/>
-                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.DiskUsage}"/>
+                    <ProgressBar Minimum="0" Maximum="100" Height="10" Value="{Binding Monitoring.DiskUsage, Mode=OneWay}"/>
                     <TextBlock Text="{Binding Monitoring.DiskTemp, StringFormat=Temp: {0}°C}"/>
                 </StackPanel>
             </GroupBox>

--- a/src/Virgil.App/Views/MainShell.xaml.cs
+++ b/src/Virgil.App/Views/MainShell.xaml.cs
@@ -167,7 +167,8 @@ namespace Virgil.App.Views
 
             if (_settingsService.Settings.ShowMiniHud)
             {
-                OnHudToggled(this, new RoutedEventArgs());
+                // Defer HUD creation until the main window is shown to avoid owner errors at startup
+                Dispatcher.BeginInvoke(new Action(() => OnHudToggled(this, new RoutedEventArgs())), DispatcherPriority.Loaded);
             }
 
         }

--- a/src/Virgil.App/Views/MiniHud.xaml
+++ b/src/Virgil.App/Views/MiniHud.xaml
@@ -4,22 +4,22 @@
   <StackPanel Orientation="Vertical" Margin="0,0,0,8">
     <StackPanel Orientation="Horizontal" Margin="0,2">
       <TextBlock Text="CPU" Width="36"/>
-      <ProgressBar Width="140" Height="8" Value="{Binding CpuUsage}" Maximum="100"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding CpuUsage, Mode=OneWay}" Maximum="100"/>
       <TextBlock Text="{Binding CpuTemp, StringFormat={}{0:F0}°C}" Margin="8,0,0,0" Width="52"/>
     </StackPanel>
     <StackPanel Orientation="Horizontal" Margin="0,2">
       <TextBlock Text="GPU" Width="36"/>
-      <ProgressBar Width="140" Height="8" Value="{Binding GpuUsage}" Maximum="100"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding GpuUsage, Mode=OneWay}" Maximum="100"/>
       <TextBlock Text="{Binding GpuTemp, StringFormat={}{0:F0}°C}" Margin="8,0,0,0" Width="52"/>
     </StackPanel>
     <StackPanel Orientation="Horizontal" Margin="0,2">
       <TextBlock Text="RAM" Width="36"/>
-      <ProgressBar Width="140" Height="8" Value="{Binding RamUsage}" Maximum="100"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding RamUsage, Mode=OneWay}" Maximum="100"/>
       <TextBlock Text="{Binding RamUsage, StringFormat={}{0:F0}%}" Margin="8,0,0,0" Width="52"/>
     </StackPanel>
     <StackPanel Orientation="Horizontal" Margin="0,2">
       <TextBlock Text="Disk" Width="36"/>
-      <ProgressBar Width="140" Height="8" Value="{Binding DiskUsage}" Maximum="100"/>
+      <ProgressBar Width="140" Height="8" Value="{Binding DiskUsage, Mode=OneWay}" Maximum="100"/>
       <TextBlock Text="{Binding DiskUsage, StringFormat={}{0:F0}%}" Margin="8,0,0,0" Width="52"/>
     </StackPanel>
   </StackPanel>


### PR DESCRIPTION
## Summary
- set monitoring progress bar bindings to OneWay to avoid TwoWay errors on read-only metrics
- keep RAM and disk bindings from crashing when monitoring view initializes

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec8c4bfac8332a37f97b2adcfb0c7)