### PR TITLE
Add offline packaging workflow assets

### DIFF
--- a/build/package-offline.ps1
+++ b/build/package-offline.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+    [string]$Runtime = "win-x64",
+    [string]$OutputRoot = "dist/offline"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$appProject = Join-Path $repoRoot "src/Virgil.App/Virgil.App.csproj"
+$packageRoot = Join-Path $repoRoot $OutputRoot
+$appOutput = Join-Path $packageRoot "app"
+
+Write-Host "🔧 Preparing offline package in '$packageRoot'" -ForegroundColor Cyan
+
+if (Test-Path $packageRoot) {
+    Remove-Item $packageRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Path $appOutput | Out-Null
+
+$publishArgs = @(
+    "publish",
+    $appProject,
+    "-c", $Configuration,
+    "-r", $Runtime,
+    "--self-contained",
+    "-o", $appOutput
+)
+
+Write-Host "📦 dotnet $($publishArgs -join ' ')" -ForegroundColor Yellow
+dotnet @publishArgs
+
+# Garantit que tous les assets offline sont présents (prompts, modèles, runner local)
+$assetSource = Join-Path $repoRoot "src/Virgil.App/assets"
+$assetTarget = Join-Path $appOutput "assets"
+if (Test-Path $assetSource) {
+    Write-Host "📁 Copying assets" -ForegroundColor Green
+    Copy-Item -Path $assetSource -Destination $assetTarget -Recurse -Force
+}
+
+# Copie la configuration par défaut pour permettre une exécution offline out-of-the-box
+$configSource = Join-Path $repoRoot "config"
+$configTarget = Join-Path $appOutput "config"
+if (Test-Path $configSource) {
+    Copy-Item -Path $configSource -Destination $configTarget -Recurse -Force
+}
+
+# Génère un manifeste lisible pour l'équipe packaging
+$manifestPath = Join-Path $packageRoot "offline-manifest.txt"
+$sizeBytes = (Get-ChildItem -Path $appOutput -Recurse | Measure-Object -Property Length -Sum).Sum
+$sizeMb = [Math]::Round($sizeBytes / 1MB, 2)
+
+$manifest = @()
+$manifest += "Virgil offline package"
+$manifest += "Configuration: $Configuration"
+$manifest += "Runtime: $Runtime"
+$manifest += "Self-contained: True"
+$manifest += "Build timestamp: $(Get-Date -Format "yyyy-MM-ddTHH:mm:ss")"
+$manifest += "Approximate size (MiB): $sizeMb"
+$manifest += "Included asset folders:"
+$manifest += "- assets/activity"
+$manifest += "- assets/avatar"
+$manifest += "- assets/voice"
+$manifest += "- assets/virgil"
+$manifest += "- assets/prompts"
+$manifest += "- assets/models"
+$manifest += "- assets/llama"
+$manifest += "Notes: add the GGUF model and llama runner binaries before building the installer."
+
+Set-Content -Path $manifestPath -Value $manifest -Encoding UTF8
+
+Write-Host "✅ Offline package ready at $appOutput" -ForegroundColor Cyan
+Write-Host "📝 Manifest generated at $manifestPath" -ForegroundColor Cyan

--- a/docs/PACKAGING_OFFLINE.md
+++ b/docs/PACKAGING_OFFLINE.md
@@ -1,0 +1,58 @@
+# Packaging offline complet (P2)
+
+Ce guide détaille la préparation d'un package d'installation 100 % offline pour Virgil afin de respecter les exigences de la backlog P2.
+
+## Objectifs
+- Inclure l'exécutable et toutes les dépendances .NET sans téléchargement runtime.
+- Embarquer l'intégralité des assets (`assets/virgil`, `assets/avatar`, `assets/activity`, `assets/voice`, `assets/prompts`, `assets/models`) et le runner LLM local.
+- Documenter les prérequis CPU/RAM/AVX et la taille approximative du package.
+- Produire un artefact unique consommable par un installeur (MSIX/Inno Setup).
+
+## Pré-requis matériels
+- Windows 10/11 x64 avec AVX/AVX2 (pour le runner `llama.cpp`).
+- 8 Go RAM minimum (16 Go recommandés pour les modèles >7B).
+- Espace disque : ~3 Go libres (dont ~2 Go pour le modèle GGUF hors debug symbols).
+
+## Structure d'assets attendue
+```
+src/Virgil.App/assets/
+├── activity/
+├── avatar/
+├── voice/
+├── virgil/
+├── prompts/
+│   └── system_prompt.sample.txt
+├── models/
+│   └── README.md (dépôt du modèle GGUF)
+└── llama/
+    └── README.md (binaire/runner local)
+```
+
+## Génération d'un package offline (script PowerShell)
+1. **Publier en self-contained** (inclut le runtime .NET) et copier les assets :
+   ```powershell
+   pwsh build/package-offline.ps1 -Configuration Release -Runtime win-x64
+   ```
+2. L'artefact est produit dans `dist/offline/app` avec un manifeste `offline-manifest.txt` résumant la build et la liste des assets.
+3. Vérifier que le modèle GGUF (`assets/models/*.gguf`) et les binaires du runner (`assets/llama/*`) sont présents **avant** de créer l'installeur.
+
+## Emballage MSIX ou Inno Setup
+- **MSIX** :
+  - Importer le contenu `dist/offline/app` dans le packaging tool Microsoft.
+  - Désactiver tout téléchargement dynamique ; fournir uniquement des chemins locaux.
+  - Déclarer les capacités nécessaires (PerformanceCounter, accès fichiers) dans l'AppxManifest.
+- **Inno Setup** :
+  - Copier récursivement `dist/offline/app` dans la section `Files`.
+  - Ajouter un prérequis AVX/AVX2 dans la section `Check` pour le runner LLM.
+  - Prévoir une option de désinstallation complète des assets (modèle, prompts, logs dans `%APPDATA%/Virgil`).
+
+## Vérifications offline
+- Tester l'installation sur une VM sans connexion réseau :
+  - Lancer l'application et vérifier qu'aucun téléchargement n'est tenté (observer les logs Serilog).
+  - Débrancher le réseau puis lancer une requête chat : l'engine doit rester fonctionnel en local.
+  - Supprimer temporairement les assets (prompts/modèle) pour confirmer la présence de fallbacks.
+- Archiver le rapport de test avec la taille finale de l'installeur.
+
+## Notes
+- Le script n'inclut pas de modèle par défaut pour limiter la taille du dépôt ; déposer le fichier GGUF correspondant dans `src/Virgil.App/assets/models/` avant publication.
+- Les prompts peuvent être personnalisés dans `assets/prompts/`; le script copie l'intégralité du dossier dans le package.

--- a/src/Virgil.App/assets/llama/README.md
+++ b/src/Virgil.App/assets/llama/README.md
@@ -1,0 +1,7 @@
+# Runner local LLM
+
+Placez ici les binaires du runner offline (par exemple `llama.cpp` buildé pour Windows x64).
+
+- Inclure `ggml.dll` ou équivalent si nécessaire.
+- Le runner doit fonctionner sans accès réseau.
+- Ajuster le script d'emballage pour pointer vers ce dossier lors de la création de l'installeur.

--- a/src/Virgil.App/assets/models/README.md
+++ b/src/Virgil.App/assets/models/README.md
@@ -1,0 +1,7 @@
+# Modèles locaux (GGUF)
+
+Déposez ici le modèle LLM au format GGUF utilisé par Virgil.
+
+- Exemple : `virgil-model.Q4_K_M.gguf`
+- Le modèle doit être embarqué dans le package offline (aucun téléchargement runtime).
+- Si aucun modèle n'est présent, l'application doit utiliser un fallback local (rule-based) pour éviter tout crash.

--- a/src/Virgil.App/assets/prompts/system_prompt.sample.txt
+++ b/src/Virgil.App/assets/prompts/system_prompt.sample.txt
@@ -1,0 +1,4 @@
+You are Virgil, a friendly offline assistant. Keep answers concise and actionable.
+- Always operate locally without downloading additional data.
+- Prefer short bullet lists for tasks.
+- If a requested asset is missing, respond with a clear fallback message.


### PR DESCRIPTION
## Summary
- add a PowerShell helper to produce a self-contained offline publish output and manifest
- document offline packaging steps, prerequisites, and validation guidance
- add placeholder assets for prompts, local model, and llama runner to ensure they are included in packages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffe6d659c8332a5efc25602f1aeb6)