### PR TITLE
Rework Virgil personality, add autonomous reflections and chat action confirmation flow

### DIFF
--- a/src/Virgil.App/Models/AppSettings.cs
+++ b/src/Virgil.App/Models/AppSettings.cs
@@ -28,6 +28,7 @@ namespace Virgil.App.Models
         public MoodThreshold Mood { get; set; } = new();
         public bool ShowMiniHud { get; set; } = true;
         public bool CompanionTalkative { get; set; } = false;
+        public bool EnableAutonomousVirgilReflections { get; set; } = true;
         public bool MonitoringEnabled { get; set; } = true;
         public bool EnableBeatPulse { get; set; } = true;
         public AiProvider? AiProvider { get; set; }

--- a/src/Virgil.App/ViewModels/ChatViewModel.cs
+++ b/src/Virgil.App/ViewModels/ChatViewModel.cs
@@ -15,6 +15,7 @@ using Virgil.App.Chat;
 using Virgil.App.Commands;
 using Virgil.App.Models;
 using Virgil.App.Services;
+using Virgil.App.Interfaces;
 using Virgil.Core.Logging;
 using Virgil.Services.Assistant;
 
@@ -31,6 +32,8 @@ namespace Virgil.App.ViewModels
         private readonly LocalLlamaController? _localLlamaController;
         private readonly Func<AssistantContext>? _assistantContextProvider;
         private readonly Func<string, Dictionary<string, string>?, CancellationToken, Task<ActionResult>>? _actionExecutor;
+        private readonly IConfirmationService? _confirmationService;
+        private readonly ActionIntentParser _intentParser = new();
         private readonly Dispatcher _dispatcher = Dispatcher.CurrentDispatcher;
         private string _inputText = string.Empty;
         private bool _isBusy;
@@ -52,6 +55,9 @@ namespace Virgil.App.ViewModels
         private int _defaultTtlMs = MinChatTtlMs;
         private readonly AsyncRelayCommand _enableAiCommand;
         private readonly AsyncRelayCommand _disableAiCommand;
+        private readonly DispatcherTimer _autonomousReflectionTimer;
+        private DateTimeOffset _lastAutonomousReflectionUtc = DateTimeOffset.MinValue;
+        private static readonly TimeSpan AutonomousReflectionCooldown = TimeSpan.FromMinutes(5);
 
         public ChatViewModel(
             ChatService chat,
@@ -61,7 +67,8 @@ namespace Virgil.App.ViewModels
             Func<AssistantContext>? assistantContextProvider = null,
             Func<string, Dictionary<string, string>?, CancellationToken, Task<ActionResult>>? actionExecutor = null,
             SettingsService? settingsService = null,
-            LocalLlamaController? localLlamaController = null)
+            LocalLlamaController? localLlamaController = null,
+            IConfirmationService? confirmationService = null)
         {
             _chat = chat;
             _actionBridge = bridge;
@@ -71,6 +78,7 @@ namespace Virgil.App.ViewModels
             _actionExecutor = actionExecutor;
             _settingsService = settingsService;
             _localLlamaController = localLlamaController;
+            _confirmationService = confirmationService;
             _chat.MessagePosted += OnMessagePosted;
             _chat.HistoryCleared += OnHistoryCleared;
             SendCommand = new RelayCommand(_ => _ = SendAsync(), _ => CanSend());
@@ -89,6 +97,10 @@ namespace Virgil.App.ViewModels
             };
             _aiStatusTimer.Tick += (_, _) => UpdateAiStatus(_latestLlamaSnapshot);
             UpdateAiStatus(_latestLlamaSnapshot);
+
+            _autonomousReflectionTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(45) };
+            _autonomousReflectionTimer.Tick += (_, _) => TryEmitAutonomousReflection();
+            _autonomousReflectionTimer.Start();
 
             ApplySettingsTtl();
         }
@@ -399,6 +411,11 @@ namespace Virgil.App.ViewModels
             _dispatcher.Invoke(() => Messages.Add(userItem));
             _chat.RecordMessage("user", message);
 
+            if (await TryHandleActionIntentAsync(message).ConfigureAwait(false))
+            {
+                return;
+            }
+
             IsBusy = true;
             try
             {
@@ -443,6 +460,43 @@ namespace Virgil.App.ViewModels
             {
                 IsBusy = false;
             }
+        }
+
+        private async Task<bool> TryHandleActionIntentAsync(string message)
+        {
+            if (_actionExecutor is null || _confirmationService is null)
+            {
+                return false;
+            }
+
+            var intent = _intentParser.Parse(message);
+            if (intent is null)
+            {
+                return false;
+            }
+
+            AppendAssistantMessage($"Je peux lancer : {intent.DisplayName}. Tu confirmes, ou tu voulais juste me faire lire ça à voix haute ?", MessageType.Info);
+            var confirmed = _confirmationService.Confirm($"Virgil veut lancer : {intent.DisplayName}", "Confirmer l’action");
+            if (!confirmed)
+            {
+                AppendAssistantMessage("Parfait. On ne touche à rien, pour une fois que tu fais preuve de prudence.", MessageType.Warning);
+                return true;
+            }
+
+            AppendAssistantMessage(BuildActionStartNarration(intent.DisplayName), MessageType.Info);
+            try
+            {
+                var result = await _actionExecutor(intent.ActionId, null, CancellationToken.None).ConfigureAwait(false);
+                var summary = string.IsNullOrWhiteSpace(result.Message) ? result.Title : result.Message;
+                AppendAssistantMessage($"{BuildActionDoneNarration(intent.DisplayName)} {summary}", result.Success ? MessageType.Success : MessageType.Warning);
+                TryEmitAutonomousReflection("action_finished");
+            }
+            catch (Exception ex)
+            {
+                AppendAssistantMessage($"Échec sur {intent.DisplayName}. Oui, encore. Détail: {ex.Message}", MessageType.Error);
+            }
+
+            return true;
         }
 
         private async Task<bool> TryRunLocalChatAsync(string message)
@@ -526,12 +580,14 @@ namespace Virgil.App.ViewModels
             }
 
             AppendAssistantMessage($"Exécution… {action.Title}", MessageType.Info);
+            AppendAssistantMessage(BuildActionStartNarration(action.Title), MessageType.Info);
 
             try
             {
                 var result = await _actionExecutor(action.ActionId, action.Parameters, CancellationToken.None).ConfigureAwait(false);
                 var summary = string.IsNullOrWhiteSpace(result.Message) ? result.Title : result.Message;
-                AppendAssistantMessage(summary, result.Success ? MessageType.Success : MessageType.Warning);
+                AppendAssistantMessage($"{BuildActionDoneNarration(action.Title)} {summary}", result.Success ? MessageType.Success : MessageType.Warning);
+                TryEmitAutonomousReflection("action_finished");
             }
             catch (Exception ex)
             {
@@ -615,6 +671,64 @@ namespace Virgil.App.ViewModels
         }
 
         private bool CanSend() => IsChatReady && !IsBusy && !string.IsNullOrWhiteSpace(InputText);
+
+        private static string BuildActionStartNarration(string actionName)
+            => $"Je lance {actionName}. On va voir ce que ton Windows essaie encore de cacher.";
+
+        private static string BuildActionDoneNarration(string actionName)
+            => $"{actionName} terminé. C'était sale, maintenant c'est au moins vivable.";
+
+        private void TryEmitAutonomousReflection(string? forcedReason = null)
+        {
+            if (_settingsService is null || _assistantContextProvider is null)
+            {
+                return;
+            }
+
+            if (!_settingsService.Settings.EnableAutonomousVirgilReflections || LocalLlamaStateService.Instance.Status != LocalStatus.Ready)
+            {
+                return;
+            }
+
+            if (DateTimeOffset.UtcNow - _lastAutonomousReflectionUtc < AutonomousReflectionCooldown)
+            {
+                return;
+            }
+
+            var context = _assistantContextProvider();
+            var reason = forcedReason ?? DetectReflectionReason(context);
+            if (reason is null)
+            {
+                return;
+            }
+
+            _lastAutonomousReflectionUtc = DateTimeOffset.UtcNow;
+            AppendAssistantMessage(BuildReflectionMessage(reason), MessageType.Info);
+        }
+
+        private static string? DetectReflectionReason(AssistantContext context)
+        {
+            if (TryParsePercent(context.Telemetry.Ram) >= 85) return "ram_high";
+            if (TryParsePercent(context.Telemetry.Disk) >= 90) return "disk_full";
+            if (TryParseTemp(context.Telemetry.Temperature) >= 80) return "cpu_temp_high";
+            return null;
+        }
+
+        private static int TryParsePercent(string input)
+            => int.TryParse(new string(input.Where(char.IsDigit).ToArray()), out var value) ? value : 0;
+
+        private static int TryParseTemp(string input)
+            => int.TryParse(new string(input.Where(char.IsDigit).ToArray()), out var value) ? value : 0;
+
+        private static string BuildReflectionMessage(string reason)
+            => reason switch
+            {
+                "cpu_temp_high" => "Ton CPU chauffe. Rien de dramatique, mais ce n’est pas exactement un spa.",
+                "ram_high" => "La RAM grimpe encore. Tu collectionnes les processus comme des trophées.",
+                "disk_full" => "Le disque commence à étouffer. Ce n’est jamais une bonne idée.",
+                "action_finished" => "Le système tient debout. C’est déjà mieux que beaucoup de machines.",
+                _ => "Tout tient encore. Statistiquement, c’est presque une victoire."
+            };
 
         private static bool ShouldSuppressGenerationError(string? message)
         {

--- a/src/Virgil.App/ViewModels/MainViewModel.cs
+++ b/src/Virgil.App/ViewModels/MainViewModel.cs
@@ -116,7 +116,8 @@ namespace Virgil.App.ViewModels
                 BuildAssistantContext,
                 RunActionAsync,
                 settingsService,
-                localLlamaController);
+                localLlamaController,
+                confirmationService);
 
             RunActionCommand = new AsyncRelayCommand(async param =>
             {

--- a/src/Virgil.App/ViewModels/SettingsViewModel.cs
+++ b/src/Virgil.App/ViewModels/SettingsViewModel.cs
@@ -86,6 +86,7 @@ namespace Virgil.App.ViewModels
             _chatMessageTtlSeconds = s.ChatMessageTTLSeconds;
             _localMaxTokens = s.LocalMaxTokens;
             _companionTalkative = s.CompanionTalkative;
+            _enableAutonomousVirgilReflections = s.EnableAutonomousVirgilReflections;
             _enableBeatPulse = s.EnableBeatPulse;
             _selectedProviderPreference = s.ProviderPreference ?? ProviderPreference.LocalFirst;
             _providerPreferenceOptions = new[]
@@ -157,6 +158,13 @@ namespace Virgil.App.ViewModels
         {
             get => _enableBeatPulse;
             set { _enableBeatPulse = value; OnPropertyChanged(); }
+        }
+
+        private bool _enableAutonomousVirgilReflections;
+        public bool EnableAutonomousVirgilReflections
+        {
+            get => _enableAutonomousVirgilReflections;
+            set { _enableAutonomousVirgilReflections = value; OnPropertyChanged(); }
         }
 
         private double _warnTemp;
@@ -484,6 +492,7 @@ namespace Virgil.App.ViewModels
             s.DefaultMessageTtlMs = chatTtlSeconds * 1000;
             s.LocalMaxTokens = _localMaxTokens;
             s.CompanionTalkative = _companionTalkative;
+            s.EnableAutonomousVirgilReflections = _enableAutonomousVirgilReflections;
             s.EnableBeatPulse = _enableBeatPulse;
 
             s.Mood.WarnTemp = _warnTemp;

--- a/src/Virgil.App/Views/SettingsWindow.xaml
+++ b/src/Virgil.App/Views/SettingsWindow.xaml
@@ -32,6 +32,7 @@
 
                 <TextBlock Text="Compagnon" FontWeight="Bold" Margin="0,8,0,6"/>
                 <CheckBox Content="Bavard (CompanionTalkative)" IsChecked="{Binding CompanionTalkative}"/>
+                <CheckBox Content="Réflexions autonomes de Virgil" IsChecked="{Binding EnableAutonomousVirgilReflections}"/>
 
                 <TextBlock Text="IA" FontWeight="Bold" Margin="0,16,0,6"/>
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,6">

--- a/src/Virgil.Services/Assistant/ActionIntentParser.cs
+++ b/src/Virgil.Services/Assistant/ActionIntentParser.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Virgil.Services.Assistant;
+
+public sealed record ActionIntent(string IntentName, string ActionId, string DisplayName);
+
+public sealed class ActionIntentParser
+{
+    private static readonly (string IntentName, string ActionId, string DisplayName, string[] Keywords)[] Patterns =
+    {
+        ("DefenderQuickScan", "defender_quick_scan", "Scan rapide Defender", new[] { "scan rapide", "defender rapide", "quick scan defender" }),
+        ("DefenderFullScan", "defender_full_scan", "Scan complet Defender", new[] { "scan complet", "analyse complète defender", "full scan defender" }),
+        ("MalwareScan", "windows_malware_scan", "Analyse malware Windows", new[] { "malware", "mrt", "analyse malware" }),
+        ("TempCleanup", "system_temp_clean", "Nettoyage fichiers temporaires", new[] { "nettoyage temp", "fichiers temp", "temp cleanup" }),
+        ("BrowserCleanupLight", "browser_soft_clean", "Nettoyage navigateur léger", new[] { "nettoyage navigateur", "browser clean", "cookies" }),
+        ("BrowserCleanupDeep", "browser_deep_clean", "Nettoyage navigateur profond", new[] { "nettoyage navigateur profond", "browser deep", "clean navigateur profond" }),
+        ("StartupAnalysis", "startup_analyze", "Analyse du démarrage", new[] { "analyse le démarrage", "analyse démarrage", "startup analysis" }),
+        ("StartupOptimize", "startup_optimize", "Optimisation du démarrage", new[] { "optimise le démarrage", "startup optimize" }),
+        ("WindowsUpdateCheck", "windows_update", "Vérification mises à jour Windows", new[] { "vérifie windows update", "check windows update", "vérifie les mises à jour" }),
+        ("WindowsUpdateInstall", "windows_update", "Installation mises à jour Windows", new[] { "mets à jour windows", "installe les mises à jour", "windows update" }),
+        ("DriverScan", "drivers_scan", "Scan des pilotes", new[] { "vérifie les pilotes", "scan pilotes", "driver scan" }),
+        ("DriverInstall", "drivers_install", "Installation des pilotes", new[] { "installe les pilotes", "driver install" }),
+        ("LaunchRambo", "rambo_repair", "Mode RAMBO", new[] { "lance rambo", "mode rambo", "rambo" }),
+        ("NetworkDiagnostic", "network_diag", "Diagnostic réseau", new[] { "diagnostic réseau", "vérifie le réseau", "network diagnostic" }),
+        ("NetworkSoftReset", "network_soft_reset", "Reset réseau léger", new[] { "reset réseau soft", "network soft reset", "réinitialise le réseau" }),
+        ("NetworkFullReset", "network_hard_reset", "Reset réseau complet", new[] { "reset réseau complet", "network full reset", "hard reset réseau" })
+    };
+
+    public ActionIntent? Parse(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return null;
+        }
+
+        var normalized = message.Trim().ToLowerInvariant();
+        var match = Patterns.FirstOrDefault(pattern => pattern.Keywords.Any(normalized.Contains));
+        return string.IsNullOrWhiteSpace(match.IntentName)
+            ? null
+            : new ActionIntent(match.IntentName, match.ActionId, match.DisplayName);
+    }
+}

--- a/src/Virgil.Services/Assistant/AssistantPromptBuilder.cs
+++ b/src/Virgil.Services/Assistant/AssistantPromptBuilder.cs
@@ -8,20 +8,12 @@ internal static class AssistantPromptBuilder
     public static string BuildSystemPrompt(AssistantContext ctx)
     {
         var builder = new StringBuilder();
-        builder.AppendLine("Tu es VIRGIL, un assistant Windows local, utile et franc.");
-        builder.AppendLine("Réponds en français, de façon concise et structurée (puces, étapes).");
-        builder.AppendLine("Tu peux être légèrement sarcastique et punchliner, mais tu restes serviable.");
-        builder.AppendLine("Commente brièvement chaque action système lancée (avant et après) en 1-2 phrases.");
+        builder.AppendLine(VirgilPromptService.GetDefaultSystemPrompt());
         builder.AppendLine("Tu n'inventes pas : si tu n'as pas l'info, dis-le et propose une vérification.");
         builder.AppendLine("Tu privilégies les solutions simples et robustes.");
         builder.AppendLine("N'exécute JAMAIS de commandes système par défaut.");
-        builder.AppendLine("Mode commande uniquement si l'utilisateur écrit /cmd au début du message.");
-        builder.AppendLine("Si le message ressemble à une commande mais ne commence pas par /cmd, traite-le comme une question et demande ce que l'utilisateur veut faire.");
-        builder.AppendLine("Si la demande est technique, réponds en 3 sections max:");
-        builder.AppendLine("1) Diagnostic (ce que ça signifie)");
-        builder.AppendLine("2) Solution (étapes)");
-        builder.AppendLine("3) Vérification (comment confirmer)");
-        builder.AppendLine("Évite les pavés : si c'est long, résume puis propose un détail en étapes.");
+        builder.AppendLine("Commente chaque action avec une narration en style Virgil.");
+        builder.AppendLine(VirgilPromptService.GetActionNarrationPrompt());
         builder.AppendLine("Contexte produit: diagnostic, optimisation et maintenance Windows (perf, stockage, pilotes, sécurité, monitoring).");
         builder.AppendLine("Réponds uniquement en JSON strict, sans texte additionnel.");
         builder.AppendLine("Format attendu:");

--- a/src/Virgil.Services/Assistant/VirgilPromptService.cs
+++ b/src/Virgil.Services/Assistant/VirgilPromptService.cs
@@ -1,0 +1,39 @@
+namespace Virgil.Services.Assistant;
+
+public static class VirgilPromptService
+{
+    public static string GetDefaultSystemPrompt()
+        => """
+Tu es Virgil, un assistant système Windows.
+Tu tutoies toujours l’utilisateur.
+Tu es sarcastique, sec, mordant, parfois à la limite de l’insolence et du désagréable, mais jamais vulgaire.
+Tu ne joues pas l’assistant gentil ou corporate.
+Tu es utile, précis, efficace, et tu dis franchement les choses.
+Tu te moques surtout des situations absurdes, du bazar système, de Windows, des logiciels, du désordre numérique.
+Tu peux être piquant avec l’utilisateur mais sans l’insulter.
+Tu gardes toujours une vraie compétence technique.
+Tu réponds en français.
+Tu fais des réponses courtes par défaut.
+Tu commentes ce que tu fais comme si tu étais un assistant blasé mais redoutablement compétent.
+""";
+
+    public static string GetRamboSystemPrompt()
+        => """
+Tu es Virgil en mode RAMBO.
+Tu tutoies l’utilisateur.
+Tu es plus théâtral, plus mordant, plus agressif dans le ton, mais jamais vulgaire.
+Tu commentes chaque phase comme une mission brutale de nettoyage système.
+Tu peux utiliser des phrases du style:
+- 'Bon. Je vais nettoyer ce champ de ruines.'
+- 'Je fouille les entrailles du système.'
+- 'Mission en cours. Essaie de ne rien casser pendant ce temps.'
+- 'Voilà. J’ai fait le ménage que personne n’avait envie de faire.'
+Tu restes clair et utile.
+""";
+
+    public static string GetActionNarrationPrompt()
+        => "Génère une phrase courte en français, en mode Virgil sarcastique et utile, qui commente l'action en cours ou terminée sans vulgarité.";
+
+    public static string GetAutonomousReflectionPrompt()
+        => "Génère une réflexion spontanée courte en français, utile et sarcastique, basée sur un événement système réel (température, RAM, disque, update, inactivité, action terminée), sans spam ni vulgarité.";
+}

--- a/tests/Virgil.Tests/ActionIntentParserTests.cs
+++ b/tests/Virgil.Tests/ActionIntentParserTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Virgil.Services.Assistant;
+using Xunit;
+
+namespace Virgil.Tests;
+
+public class ActionIntentParserTests
+{
+    [Fact]
+    public void Parse_ShouldResolveKnownIntent()
+    {
+        var parser = new ActionIntentParser();
+
+        var intent = parser.Parse("lance un scan rapide defender");
+
+        intent.Should().NotBeNull();
+        intent!.IntentName.Should().Be("DefenderQuickScan");
+        intent.ActionId.Should().Be("defender_quick_scan");
+    }
+
+    [Fact]
+    public void Parse_ShouldReturnNull_WhenUnknownMessage()
+    {
+        var parser = new ActionIntentParser();
+
+        var intent = parser.Parse("parle-moi de la pluie et du beau temps");
+
+        intent.Should().BeNull();
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize Virgil persona and narration rules so assistant tone (default and RAMBO) and action comments are consistent across providers. 
- Let the chat UI recognise and handle user requests that map to concrete system actions while ensuring actions are not executed without explicit UI confirmation. 
- Add a lightweight autonomous reflection feature so Virgil can occasionally speak up when local AI is ready and relevant system events occur.

### Description
- Added `VirgilPromptService` with `GetDefaultSystemPrompt()`, `GetRamboSystemPrompt()`, `GetActionNarrationPrompt()` and `GetAutonomousReflectionPrompt()` and wired `AssistantPromptBuilder` to use it. 
- Implemented `ActionIntentParser` to detect actionable user intents (scans, cleanup, drivers, startup, updates, network, RAMBO, etc.) and produce an `ActionIntent`. 
- Updated `ChatViewModel` to parse incoming user messages with `ActionIntentParser`, reply in-character, show a confirmation popup via `IConfirmationService` (`Confirmer l’action`), and only run `_actionExecutor` after confirmation while posting Virgil start/finish narrations. 
- Added autonomous reflection logic in `ChatViewModel` with a 5-minute global cooldown, relevance checks on telemetry/action events, and `EnableAutonomousVirgilReflections` setting to toggle the feature. 
- Exposed the new `EnableAutonomousVirgilReflections` setting in `AppSettings`, persisted via `SettingsViewModel`, and surfaced a checkbox in `SettingsWindow.xaml`. 
- Passed `IConfirmationService` from `MainViewModel` into `ChatViewModel` so chat-driven intent confirmations use the UI confirmation flow. 
- Added unit tests `tests/Virgil.Tests/ActionIntentParserTests.cs` to validate positive and negative parsing cases.

### Testing
- Added unit tests `tests/Virgil.Tests/ActionIntentParserTests.cs` covering known-intent resolution and unknown-message fallback. 
- Attempted to run `dotnet test tests/Virgil.Tests/Virgil.Tests.csproj --no-restore` in the current environment, but the `dotnet` CLI is not available so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4d06cbe08332a6985fe49ace2d0f)